### PR TITLE
feature: Make radius optional.

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -49,7 +49,7 @@ fn setup(
             // Set the starting position
             alpha: TAU / 8.0,
             beta: TAU / 8.0,
-            radius: 5.0,
+            radius: Some(5.0),
             // Set limits on the position
             alpha_upper_limit: Some(TAU / 4.0),
             alpha_lower_limit: Some(-TAU / 4.0),


### PR DESCRIPTION
Don't usurp camera position initially. If radius is not set, compute the radius from the camera's position and the focus as its initial setting.

Default radius is left at `Some(5.0)` so its behavior isn't changed in the examples, but I'd be tempted to have the default set to None, since moving the camera to 5 away from focus is arbitrary and surprising.