### PR TITLE
Add multiple viewport/window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Default controls:
 - Smooth orbiting motion
 - Works with orthographic camera projection in addition to perspective
 - Customisable controls and sensitivity
-- Works with multiple viewports and windows
+- Works with multiple viewports and/or windows
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Default controls:
 ## Features
 
 - Smooth orbiting motion
-- Orthographic camera projection in addition to perspective
+- Works with orthographic camera projection in addition to perspective
 - Customisable controls and sensitivity
+- Works with multiple viewports and windows
 
 ## Quick Start
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,4 +1,5 @@
-/// An example showing all configuration options
+//! Demonstrates all common configuration options
+
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 use std::f32::consts::TAU;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
-/// An example showing how to set up PanOrbitCamera with default configuration
+//! Demonstrates the simplest usage
+
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 

--- a/examples/multiple_viewports_windows.rs
+++ b/examples/multiple_viewports_windows.rs
@@ -1,0 +1,142 @@
+//! Demonstrates usage with multiple viewports and windows
+//! Adapted from the official bevy examples, split_screen and multiple_windows
+
+use bevy::core_pipeline::clear_color::ClearColorConfig;
+use bevy::prelude::*;
+use bevy::render::camera::{RenderTarget, Viewport};
+use bevy::window::{WindowRef, WindowResized};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use std::f32::consts::TAU;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PanOrbitCameraPlugin)
+        .add_startup_system(setup)
+        .add_system(set_camera_viewports)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // Left Camera
+    commands.spawn((
+        Camera3dBundle { ..default() },
+        PanOrbitCamera {
+            beta: TAU * 0.1,
+            ..default()
+        },
+        LeftCamera,
+    ));
+    // Right Camera
+    commands.spawn((
+        Camera3dBundle {
+            camera: Camera {
+                // Renders the right camera after the left camera, which has a default priority of 0
+                order: 1,
+                ..default()
+            },
+            camera_3d: Camera3d {
+                // don't clear on the second camera because the first camera already cleared the window
+                clear_color: ClearColorConfig::None,
+                ..default()
+            },
+            ..default()
+        },
+        PanOrbitCamera {
+            beta: TAU * 0.1,
+            alpha: TAU * 0.1,
+            ..default()
+        },
+        RightCamera,
+    ));
+
+    // Spawn a second window
+    let second_window = commands
+        .spawn(Window {
+            title: "Second window".to_owned(),
+            ..default()
+        })
+        .id();
+
+    // second window camera
+    commands.spawn((
+        Camera3dBundle {
+            camera: Camera {
+                target: RenderTarget::Window(WindowRef::Entity(second_window)),
+                ..default()
+            },
+            ..default()
+        },
+        PanOrbitCamera {
+            beta: TAU * 0.05,
+            radius: 8.0,
+            ..default()
+        },
+    ));
+}
+
+#[derive(Component)]
+struct LeftCamera;
+
+#[derive(Component)]
+struct RightCamera;
+
+fn set_camera_viewports(
+    windows: Query<&Window>,
+    mut resize_events: EventReader<WindowResized>,
+    mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
+    mut right_camera: Query<&mut Camera, With<RightCamera>>,
+) {
+    // We need to dynamically resize the camera's viewports whenever the window size changes
+    // so then each camera always takes up half the screen.
+    // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.
+    for resize_event in resize_events.iter() {
+        let window = windows.get(resize_event.window).unwrap();
+        let mut left_camera = left_camera.single_mut();
+        left_camera.viewport = Some(Viewport {
+            physical_position: UVec2::new(0, 0),
+            physical_size: UVec2::new(
+                window.resolution.physical_width() / 2,
+                window.resolution.physical_height(),
+            ),
+            ..default()
+        });
+
+        let mut right_camera = right_camera.single_mut();
+        right_camera.viewport = Some(Viewport {
+            physical_position: UVec2::new(window.resolution.physical_width() / 2, 0),
+            physical_size: UVec2::new(
+                window.resolution.physical_width() / 2,
+                window.resolution.physical_height(),
+            ),
+            ..default()
+        });
+    }
+}

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -1,0 +1,78 @@
+//! Demonstrates usage with multiple windows
+
+use bevy::core_pipeline::clear_color::ClearColorConfig;
+use bevy::prelude::*;
+use bevy::render::camera::{RenderTarget, Viewport};
+use bevy::window::{WindowRef, WindowResized};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use std::f32::consts::TAU;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PanOrbitCameraPlugin)
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // Camera
+    commands.spawn((
+        Camera3dBundle { ..default() },
+        PanOrbitCamera {
+            beta: TAU * 0.1,
+            ..default()
+        },
+    ));
+
+    // Spawn a second window
+    let second_window = commands
+        .spawn(Window {
+            title: "Second window".to_owned(),
+            ..default()
+        })
+        .id();
+
+    // second window camera
+    commands.spawn((
+        Camera3dBundle {
+            camera: Camera {
+                target: RenderTarget::Window(WindowRef::Entity(second_window)),
+                ..default()
+            },
+            ..default()
+        },
+        PanOrbitCamera {
+            beta: TAU * 0.05,
+            radius: 8.0,
+            ..default()
+        },
+    ));
+}


### PR DESCRIPTION
Makes it work with multiple viewports and windows, rather than hard coding the primary window.

Orbiting rotation amount is calculated from the window size, rather than the viewport. I did this as using viewport size for rotation meant that small viewports had much too high sensitivity. That's because the amount of rotation is 360 degrees if you go edge to edge. For small viewports, that physical distance may be very small.

Panning is calculated from the viewport size, as it needs to be 1:1 with the mouse.

Demos:


https://user-images.githubusercontent.com/7709415/234175395-1b148e89-a68e-43d1-82cb-644f40bb5874.mp4


https://user-images.githubusercontent.com/7709415/234175427-8fe3cdf6-f34c-47d6-8225-fa3ab0d4bd21.mp4

