### PR TITLE
Add orbit_smoothness option, fix bug, and add animation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Default controls:
 - Works with orthographic camera projection in addition to perspective
 - Customisable controls, sensitivity, and more
 - Works with multiple viewports and/or windows
+- Easy to animate, e.g. to slowly rotate around an object
 
 ## Quick Start
 

--- a/examples/animate.rs
+++ b/examples/animate.rs
@@ -1,0 +1,65 @@
+//! Demonstrates how you can animate the movement of the camera
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use std::f32::consts::TAU;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PanOrbitCameraPlugin)
+        .add_startup_system(setup)
+        .add_system(animate)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // Camera
+    commands.spawn((
+        Camera3dBundle::default(),
+        PanOrbitCamera {
+            // Optionally disable smoothing to have full control over the camera's position
+            // orbit_smoothness: 0.0,
+            // Might want to disable the controls
+            enabled: false,
+            ..default()
+        },
+    ));
+}
+
+// Animate the camera's position
+fn animate(time: Res<Time>, mut pan_orbit_query: Query<&mut PanOrbitCamera>) {
+    for mut pan_orbit in pan_orbit_query.iter_mut() {
+        // Must set target values, not alpha/beta directly
+        pan_orbit.target_alpha += 15f32.to_radians() * time.delta_seconds();
+        pan_orbit.target_beta = time.elapsed_seconds_wrapped().sin() * TAU * 0.1;
+        pan_orbit.radius = (((time.elapsed_seconds_wrapped() * 2.0).cos() + 1.0) * 0.5) * 2.0 + 4.0;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,7 +469,7 @@ fn pan_orbit_camera(
             || pan_orbit.target_alpha != pan_orbit.alpha
             || pan_orbit.target_beta != pan_orbit.beta
         {
-            // Otherwise, interpolate our way there
+            // Interpolate towards the target value
             let t = 1.0 - pan_orbit.orbit_smoothness;
             let mut target_alpha = pan_orbit.alpha.lerp(&pan_orbit.target_alpha, &t);
             let mut target_beta = pan_orbit.beta.lerp(&pan_orbit.target_beta, &t);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ pub struct PanOrbitCamera {
     /// The sensitivity of the orbiting motion. Defaults to `1.0`.
     pub orbit_sensitivity: f32,
     /// How much smoothing is applied to the orbit motion. A value of `0.0` disables smoothing,
-    /// so there's a 1:1 mapping of input to camera position. A value of `1.0` is infinite,
-    /// smoothing, which you probably don't want. Defaults to `0.8`.
+    /// so there's a 1:1 mapping of input to camera position. A value of `1.0` is infinite
+    /// smoothing. Defaults to `0.8`.
     pub orbit_smoothness: f32,
     /// The sensitivity of the panning motion. Defaults to `1.0`.
     pub pan_sensitivity: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,12 +335,6 @@ fn pan_orbit_camera(
             continue;
         }
 
-        // Abort early if this camera not active. Do this after initializing so cameras are always
-        // initialized.
-        if active_viewport_data.entity != Some(entity) {
-            continue;
-        }
-
         // 1 - Get Input
 
         let mut pan = Vec2::ZERO;
@@ -348,7 +342,7 @@ fn pan_orbit_camera(
         let mut scroll = 0.0;
         let mut orbit_button_changed = false;
 
-        if pan_orbit.enabled {
+        if pan_orbit.enabled && active_viewport_data.entity == Some(entity) {
             if orbit_pressed(&pan_orbit, &mouse_input, &key_input) {
                 rotation_move += mouse_delta * pan_orbit.orbit_sensitivity;
             } else if pan_pressed(&pan_orbit, &mouse_input, &key_input) {


### PR DESCRIPTION
* Adds `orbit_smoothness` option so you can change how smooth the orbiting motion is
* Fixes bug that meant you could only programmatically update the camera's position if it was the 'active' camera. This meant that a) you had to click once before it would work, and b) you could only control one camera at a time.
* Add `animate` example which demos how to animate the camera's motion
* Minor renaming and comment fixing