### PR TITLE
Keep processing if target alpha/beta is not the same as current

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_panorbit_camera"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Plonq"]
 edition = "2021"
 description = "A basic pan and orbit camera in Bevy"

--- a/examples/keyboard_controls.rs
+++ b/examples/keyboard_controls.rs
@@ -2,7 +2,6 @@
 
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
-use std::f32::consts::TAU;
 
 fn main() {
     App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,11 @@ fn pan_orbit_camera(
 
         // 4 - Apply orbit rotation based on target alpha/beta
 
-        if has_moved || pan_orbit.force_update {
+        if has_moved
+            || pan_orbit.target_alpha != pan_orbit.alpha
+            || pan_orbit.target_beta != pan_orbit.beta
+            || pan_orbit.force_update
+        {
             // Interpolate towards the target value
             let t = 1.0 - pan_orbit.orbit_smoothness;
             let mut target_alpha = pan_orbit.alpha.lerp(&pan_orbit.target_alpha, &t);


### PR DESCRIPTION
Fixes regression introduced in 0.4.0, where the camera would stop when you let go of the mouse.