### PR TITLE
Convert system set to base set to fix bug with egui feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl Plugin for PanOrbitCameraPlugin {
             .add_systems(
                 (active_viewport_data, pan_orbit_camera)
                     .chain()
-                    .in_set(PanOrbitCameraSystemSet),
+                    .in_base_set(PanOrbitCameraSystemSet),
             );
 
         #[cfg(feature = "bevy_egui")]
@@ -50,8 +50,9 @@ impl Plugin for PanOrbitCameraPlugin {
     }
 }
 
-/// System set to allow ordering of `PanOrbitCamera`
+/// Base system set to allow ordering of `PanOrbitCamera`
 #[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[system_set(base)]
 pub struct PanOrbitCameraSystemSet;
 
 /// Tags an entity as capable of panning and orbiting, and provides a way to configure the


### PR DESCRIPTION
Fixes #14 

I found that when the exit condition was set to `OnPrimaryClosed`, as soon as the run condition returned false, the `check_egui_wants_focus` system stopped executing. I can see how this makes sense, because the system was set to run before `PanOrbitCameraSystemSet` which is now not running. But I am not sure if that's actually how Bevy works. Additionally, it _does_ run regardless if `OnAllClosed` exit condition is used. Whatever the cause may be, using a base set instead works as expected. Base sets are also the only example of system sets I can find in the official examples, which may hint at something...