### PR TITLE
Revamped, more flexible initialization code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bevy_egui = { version = "0.20", optional = true, default-features = false }
 [dev-dependencies]
 bevy = { version = "0.10" }
 bevy-inspector-egui = { version = "0.18.3", default-features = false }
+float-cmp = "0.9.0"
 
 [[example]]
 name = "egui"

--- a/README.md
+++ b/README.md
@@ -39,36 +39,25 @@ Add the plugin:
 Add `PanOrbitCamera` to a camera:
 
 ```rust ignore
-commands
-    .spawn((
-        Camera3dBundle::default(),
-        PanOrbitCamera::default(),
-    ));
+commands.spawn((
+    Camera3dBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+        ..default()
+    },
+    PanOrbitCamera::default(),
+));
 ```
 
 This will set up a camera with good defaults.
 
-Optionally configure settings:
-
-```rust ignore
-commands
-    .spawn((
-        Camera3dBundle::default(),
-        PanOrbitCamera {
-            beta: TAU * 0.1,
-            radius: 5.0,
-        },
-    ));
-```
-
 Check out the [advanced example](https://github.com/Plonq/bevy_panorbit_camera/tree/master/examples/advanced.rs) to see
-all the possible options.
+all the possible configuration options.
 
 ## What are `alpha` and `beta`?
 
 Think of this camera as rotating around a point, and always pointing at that point (the `focus`). The sideways rotation,
 i.e. the longitudinal rotation, is `alpha`, and the latitudinal rotation is `beta`. Both are measured in radians.
-If `alpha` and `beta` are both `0.0`, then the camera will be pointing directly forwards (-Z direction). Increasing
+If `alpha` and `beta` are both `0.0`, then the camera will be looking directly forwards (-Z direction). Increasing
 `alpha` will rotate around the `focus` to the right, and increasing `beta` will move the camera up and over the `focus`.
 
 ## Cargo Features

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,4 +1,5 @@
-//! Demonstrates all common configuration options
+//! Demonstrates all common configuration options,
+//! and how to modify them at runtime
 
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
@@ -43,15 +44,17 @@ fn setup(
     });
     // Camera
     commands.spawn((
+        // Note we're setting the initial position below with alpha, beta, and radius, hence
+        // we don't set transform on the camera.
         Camera3dBundle::default(),
         PanOrbitCamera {
-            // Set focal point
+            // Set focal point (what the camera should look at)
             focus: Vec3::new(0.0, 1.0, 0.0),
-            // Set the starting position
-            alpha: TAU / 8.0,
-            beta: TAU / 8.0,
-            radius: 5.0,
-            // Set limits on the position
+            // Set the starting position, relative to focus (overrides camera's transform).
+            alpha: Some(TAU / 8.0),
+            beta: Some(TAU / 8.0),
+            radius: Some(5.0),
+            // Set limits on how far in will rotate
             alpha_upper_limit: Some(TAU / 4.0),
             alpha_lower_limit: Some(-TAU / 4.0),
             beta_upper_limit: Some(TAU / 3.0),
@@ -62,14 +65,12 @@ fn setup(
             zoom_sensitivity: 0.5,
             // Allow the camera to go upside down
             allow_upside_down: true,
-            // Blender-like key bindings
+            // Change the controls (these match Blender)
             button_orbit: MouseButton::Middle,
             button_pan: MouseButton::Middle,
             modifier_pan: Some(KeyCode::LShift),
             // Reverse the zoom direction
             reversed_zoom: true,
-            // Makes sure it's enabled (this is default)
-            enabled: true,
             ..default()
         },
     ));

--- a/examples/animate.rs
+++ b/examples/animate.rs
@@ -43,11 +43,14 @@ fn setup(
     });
     // Camera
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+            ..default()
+        },
         PanOrbitCamera {
             // Disable smoothing, since the animation takes care of that
             orbit_smoothness: 0.0,
-            // Might want to disable the controls
+            // Probably want to disable the controls
             enabled: false,
             ..default()
         },
@@ -60,7 +63,8 @@ fn animate(time: Res<Time>, mut pan_orbit_query: Query<&mut PanOrbitCamera>) {
         // Must set target values, not alpha/beta directly
         pan_orbit.target_alpha += 15f32.to_radians() * time.delta_seconds();
         pan_orbit.target_beta = time.elapsed_seconds_wrapped().sin() * TAU * 0.1;
-        pan_orbit.radius = (((time.elapsed_seconds_wrapped() * 2.0).cos() + 1.0) * 0.5) * 2.0 + 4.0;
+        pan_orbit.radius =
+            Some((((time.elapsed_seconds_wrapped() * 2.0).cos() + 1.0) * 0.5) * 2.0 + 4.0);
 
         // Force camera to update its transform
         pan_orbit.force_update = true;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -40,5 +40,11 @@ fn setup(
         ..default()
     });
     // Camera
-    commands.spawn((Camera3dBundle::default(), PanOrbitCamera::default()));
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+            ..default()
+        },
+        PanOrbitCamera::default(),
+    ));
 }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -43,5 +43,11 @@ fn setup(
         ..default()
     });
     // Camera
-    commands.spawn((Camera3dBundle::default(), PanOrbitCamera::default()));
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+            ..default()
+        },
+        PanOrbitCamera::default(),
+    ));
 }

--- a/examples/keyboard_controls.rs
+++ b/examples/keyboard_controls.rs
@@ -41,7 +41,13 @@ fn setup(
         ..default()
     });
     // Camera
-    commands.spawn((Camera3dBundle::default(), PanOrbitCamera::default()));
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+            ..default()
+        },
+        PanOrbitCamera::default(),
+    ));
 }
 
 fn keyboard_controls(
@@ -100,10 +106,14 @@ fn keyboard_controls(
 
             // Zoom with Z and X
             if key_input.pressed(KeyCode::Z) {
-                pan_orbit.radius -= 5.0 * time.delta_seconds();
+                pan_orbit.radius = pan_orbit
+                    .radius
+                    .map(|radius| radius - 5.0 * time.delta_seconds());
             }
             if key_input.pressed(KeyCode::X) {
-                pan_orbit.radius += 5.0 * time.delta_seconds();
+                pan_orbit.radius = pan_orbit
+                    .radius
+                    .map(|radius| radius + 5.0 * time.delta_seconds());
             }
         }
 

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -46,15 +46,16 @@ fn setup(
     });
     // Main Camera
     commands.spawn((
-        Camera3dBundle { ..default() },
-        PanOrbitCamera {
-            beta: TAU * 0.1,
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 0.5, 5.0)),
             ..default()
         },
+        PanOrbitCamera::default(),
     ));
     // Minimap Camera
     commands.spawn((
         Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(1.0, 1.5, 4.0)),
             camera: Camera {
                 // Renders the minimap camera after the main camera, so it is rendered on top
                 order: 1,
@@ -67,11 +68,7 @@ fn setup(
             },
             ..default()
         },
-        PanOrbitCamera {
-            beta: TAU * 0.1,
-            alpha: TAU * 0.1,
-            ..default()
-        },
+        PanOrbitCamera::default(),
         MinimapCamera,
     ));
 }

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -44,11 +44,11 @@ fn setup(
     });
     // Camera
     commands.spawn((
-        Camera3dBundle { ..default() },
-        PanOrbitCamera {
-            beta: TAU * 0.1,
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
             ..default()
         },
+        PanOrbitCamera::default(),
     ));
 
     // Spawn a second window
@@ -62,16 +62,13 @@ fn setup(
     // second window camera
     commands.spawn((
         Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(5.0, 1.5, 7.0)),
             camera: Camera {
                 target: RenderTarget::Window(WindowRef::Entity(second_window)),
                 ..default()
             },
             ..default()
         },
-        PanOrbitCamera {
-            beta: TAU * 0.05,
-            radius: 8.0,
-            ..default()
-        },
+        PanOrbitCamera::default(),
     ));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,8 @@ fn active_viewport_data(
     let mut max_cam_order = 0;
 
     for (entity, camera, pan_orbit) in orbit_cameras.iter() {
-        let input_just_activated = orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
-            || pan_just_pressed(pan_orbit, &mouse_input, &key_input)
+        let input_just_activated = util::orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
+            || util::pan_just_pressed(pan_orbit, &mouse_input, &key_input)
             || !scroll_events.is_empty();
 
         if input_just_activated {
@@ -329,7 +329,7 @@ fn pan_orbit_camera(
                 p.scale = radius;
             }
 
-            update_orbit_transform(alpha, beta, &pan_orbit, &mut transform);
+            util::update_orbit_transform(alpha, beta, &pan_orbit, &mut transform);
             pan_orbit.alpha = Some(alpha);
             pan_orbit.beta = Some(beta);
             pan_orbit.radius = Some(radius);
@@ -347,9 +347,9 @@ fn pan_orbit_camera(
         let mut orbit_button_changed = false;
 
         if pan_orbit.enabled && active_cam.entity == Some(entity) {
-            if orbit_pressed(&pan_orbit, &mouse_input, &key_input) {
+            if util::orbit_pressed(&pan_orbit, &mouse_input, &key_input) {
                 rotation_move += mouse_delta * pan_orbit.orbit_sensitivity;
-            } else if pan_pressed(&pan_orbit, &mouse_input, &key_input) {
+            } else if util::pan_pressed(&pan_orbit, &mouse_input, &key_input) {
                 // Pan only if we're not rotating at the moment
                 pan += mouse_delta * pan_orbit.pan_sensitivity;
             }
@@ -366,8 +366,8 @@ fn pan_orbit_camera(
                 scroll += ev.y * multiplier * direction * pan_orbit.zoom_sensitivity;
             }
 
-            if orbit_just_pressed(&pan_orbit, &mouse_input, &key_input)
-                || orbit_just_released(&pan_orbit, &mouse_input, &key_input)
+            if util::orbit_just_pressed(&pan_orbit, &mouse_input, &key_input)
+                || util::orbit_just_released(&pan_orbit, &mouse_input, &key_input)
             {
                 orbit_button_changed = true;
             }
@@ -489,7 +489,7 @@ fn pan_orbit_camera(
                     target_beta = pan_orbit.target_beta;
                 }
 
-                update_orbit_transform(target_alpha, target_beta, &pan_orbit, &mut transform);
+                util::update_orbit_transform(target_alpha, target_beta, &pan_orbit, &mut transform);
 
                 // Update current alpha and beta values
                 pan_orbit.alpha = Some(target_alpha);
@@ -500,105 +500,5 @@ fn pan_orbit_camera(
                 }
             }
         }
-    }
-}
-
-fn orbit_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let is_pressed = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && mouse_input.pressed(pan_orbit.button_orbit);
-
-    is_pressed
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-fn orbit_just_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_pressed = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_pressed(pan_orbit.button_orbit));
-
-    just_pressed
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-fn orbit_just_released(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_released = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_released(pan_orbit.button_orbit));
-
-    just_released
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-fn pan_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let is_pressed = pan_orbit
-        .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && mouse_input.pressed(pan_orbit.button_pan);
-
-    is_pressed
-        && pan_orbit
-            .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-fn pan_just_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_pressed = pan_orbit
-        .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_pressed(pan_orbit.button_pan));
-
-    just_pressed
-        && pan_orbit
-            .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-/// Update `transform` based on alpha, beta, and the camera's focus and radius
-fn update_orbit_transform(
-    alpha: f32,
-    beta: f32,
-    pan_orbit: &PanOrbitCamera,
-    transform: &mut Transform,
-) {
-    if let Some(radius) = pan_orbit.radius {
-        let mut rotation = Quat::from_rotation_y(alpha);
-        rotation *= Quat::from_rotation_x(-beta);
-
-        transform.rotation = rotation;
-
-        // Update the translation of the camera so we are always rotating 'around'
-        // (orbiting) rather than rotating in place
-        let rot_matrix = Mat3::from_quat(transform.rotation);
-        transform.translation = pan_orbit.focus + rot_matrix.mul_vec3(Vec3::new(0.0, 0.0, radius));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,73 @@
+use bevy::math::Vec3;
+
+pub fn calculate_from_translation_and_focus(translation: Vec3, focus: Vec3) -> (f32, f32, f32) {
+    let comp_vec = translation - focus;
+    let mut radius = comp_vec.length();
+    if radius == 0.0 {
+        radius = 0.05; // Radius 0 causes problems
+    }
+    let alpha = if comp_vec.x == 0.0 && comp_vec.z >= 0.0 {
+        0.0
+    } else {
+        (comp_vec.z / (comp_vec.x.powi(2) + comp_vec.z.powi(2)).sqrt()).acos()
+    };
+    let beta = (comp_vec.y / radius).asin();
+    (alpha, beta, radius)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use float_cmp::approx_eq;
+    use std::f32::consts::PI;
+
+    #[test]
+    fn test_zero() {
+        let translation = Vec3::new(0.0, 0.0, 0.0);
+        let focus = Vec3::ZERO;
+        let (alpha, beta, radius) = calculate_from_translation_and_focus(translation, focus);
+        assert_eq!(alpha, 0.0);
+        assert_eq!(beta, 0.0);
+        assert_eq!(radius, 0.05);
+    }
+
+    #[test]
+    fn test_in_front() {
+        let translation = Vec3::new(0.0, 0.0, 5.0);
+        let focus = Vec3::ZERO;
+        let (alpha, beta, radius) = calculate_from_translation_and_focus(translation, focus);
+        assert_eq!(alpha, 0.0);
+        assert_eq!(beta, 0.0);
+        assert_eq!(radius, 5.0);
+    }
+
+    #[test]
+    fn test_to_the_side() {
+        let translation = Vec3::new(5.0, 0.0, 0.0);
+        let focus = Vec3::ZERO;
+        let (alpha, beta, radius) = calculate_from_translation_and_focus(translation, focus);
+        assert!(approx_eq!(f32, alpha, PI / 2.0));
+        assert_eq!(beta, 0.0);
+        assert_eq!(radius, 5.0);
+    }
+
+    #[test]
+    fn test_above() {
+        let translation = Vec3::new(0.0, 5.0, 0.0);
+        let focus = Vec3::ZERO;
+        let (alpha, beta, radius) = calculate_from_translation_and_focus(translation, focus);
+        assert_eq!(alpha, 0.0);
+        assert!(approx_eq!(f32, beta, PI / 2.0));
+        assert_eq!(radius, 5.0);
+    }
+
+    #[test]
+    fn test_arbitrary() {
+        let translation = Vec3::new(0.92563736, 3.864204, -1.0105048);
+        let focus = Vec3::ZERO;
+        let (alpha, beta, radius) = calculate_from_translation_and_focus(translation, focus);
+        assert!(approx_eq!(f32, alpha, 2.4));
+        assert!(approx_eq!(f32, beta, 1.23));
+        assert_eq!(radius, 4.1);
+    }
+}


### PR DESCRIPTION
This revamps how we initialize. Use camera position to calculate initial alpha, beta, and radius, if they aren't set. If they are, override camera's position instead.

This also removes the (actually broken, I realised) constructor method `from_translation_and_focus` that creates an instance from a transform, since it is now redundant.

This includes some other minor improvements to documentation and various small cleanup things.

Thanks to https://github.com/Plonq/bevy_panorbit_camera/pull/4 for the idea of this change.