### PR TITLE
Add zoom limits for orthographic projections

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -59,6 +59,9 @@ fn setup(
             alpha_lower_limit: Some(-TAU / 4.0),
             beta_upper_limit: Some(TAU / 3.0),
             beta_lower_limit: Some(-TAU / 3.0),
+            // Set zoom limits
+            scale_upper_limit: Some(50.0),
+            scale_lower_limit: Some(10.0),
             // Adjust sensitivity of controls
             orbit_sensitivity: 1.5,
             pan_sensitivity: 0.5,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,6 +481,7 @@ fn pan_orbit_camera(
             } else {
                 pan_orbit.radius = pan_orbit
                     .radius
+                    // Prevent zoom to zero otherwise we can get stuck there
                     .map(|radius| f32::max(radius - scroll * radius * 0.2, 0.05));
             }
             has_moved = true;


### PR DESCRIPTION
Allows setting an upper/lower limit on projection scale for orthographic projections to limit zoom