### PR TITLE
Add zoom limiting

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -54,11 +54,13 @@ fn setup(
             alpha: Some(TAU / 8.0),
             beta: Some(TAU / 8.0),
             radius: Some(5.0),
-            // Set limits on how far in will rotate
+            // Set limits on rotation and zoom
             alpha_upper_limit: Some(TAU / 4.0),
             alpha_lower_limit: Some(-TAU / 4.0),
             beta_upper_limit: Some(TAU / 3.0),
             beta_lower_limit: Some(-TAU / 3.0),
+            zoom_upper_limit: Some(5.0),
+            zoom_lower_limit: Some(1.0),
             // Adjust sensitivity of controls
             orbit_sensitivity: 1.5,
             pan_sensitivity: 0.5,

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -51,10 +51,6 @@ fn setup(
             }),
             ..default()
         },
-        PanOrbitCamera {
-            zoom_upper_limit: Some(2.0),
-            zoom_lower_limit: Some(1.0),
-            ..default()
-        },
+        PanOrbitCamera::default(),
     ));
 }

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -51,6 +51,10 @@ fn setup(
             }),
             ..default()
         },
-        PanOrbitCamera::default(),
+        PanOrbitCamera {
+            zoom_upper_limit: Some(2.0),
+            zoom_lower_limit: Some(1.0),
+            ..default()
+        },
     ));
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,6 +118,19 @@ pub fn update_orbit_transform(
     }
 }
 
+pub fn apply_zoom_limits(value: f32, upper_limit: Option<f32>, lower_limit: Option<f32>) -> f32 {
+    let mut new_val = value;
+    if let Some(zoom_upper) = upper_limit {
+        new_val = f32::min(new_val, zoom_upper);
+    }
+    if let Some(zoom_lower) = lower_limit {
+        new_val = f32::max(new_val, zoom_lower);
+    }
+    // Prevent zoom to zero otherwise we can get stuck there because zoom
+    // amount scales based on distance
+    f32::max(new_val, 0.05)
+}
+
 #[cfg(test)]
 mod calculate_from_translation_and_focus_tests {
     use super::*;


### PR DESCRIPTION
Adds zoom limiting, which will apply to radius or scale, depending on the camera's projection.

Credit goes to @mrivnak for the idea and part of the implementation in [their PR](https://github.com/Plonq/bevy_panorbit_camera/pull/26) - thanks!