### PR TITLE
Render to texture support

### DIFF
--- a/examples/manual_override.rs
+++ b/examples/manual_override.rs
@@ -1,0 +1,119 @@
+//! Demonstrates the ability to manually override which instance of PanOrbitCamera receives input,
+//! and how that input is scaled.
+//! This effectively disables automatic handling of multiple viewport/windows, but may be suitable
+//! if you have a unique situation, for example when the camera you want to control is rendering to
+//! a texture instead of a window.
+
+use bevy::core_pipeline::clear_color::ClearColorConfig;
+use bevy::prelude::*;
+use bevy::render::camera::Viewport;
+use bevy::window::{PrimaryWindow, WindowResized};
+use bevy_panorbit_camera::{ActiveCameraData, PanOrbitCamera, PanOrbitCameraPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (update_active_cam, set_camera_viewports))
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // Main Camera
+    commands.spawn((Camera3dBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 0.5, 5.0)),
+        ..default()
+    },));
+    // Minimap Camera
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(1.0, 1.5, 4.0)),
+            camera: Camera {
+                // Renders the minimap camera after the main camera, so it is rendered on top
+                order: 1,
+                ..default()
+            },
+            camera_3d: Camera3d {
+                // Don't clear on the second camera because the first camera already cleared the window
+                clear_color: ClearColorConfig::None,
+                ..default()
+            },
+            ..default()
+        },
+        PanOrbitCamera::default(),
+        MinimapCamera,
+    ));
+}
+
+#[derive(Component)]
+struct MinimapCamera;
+
+fn update_active_cam(
+    mut active_cam: ResMut<ActiveCameraData>,
+    minimap_camera_q: Query<(Entity, &Camera), With<MinimapCamera>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let primary_window = windows
+        .get_single()
+        .expect("There is only ever one primary camera");
+    let (minimap_camera_id, minimap_camera) =
+        minimap_camera_q.get_single().expect("We only added one");
+    active_cam.set_if_neq(ActiveCameraData {
+        // Set the entity to the entity ID of the camera you want to control
+        entity: Some(minimap_camera_id),
+        // Set the viewport and window size based on how you want the mouse motion to be scaled.
+        // The viewport size is used to scale pan motion in order to get 1:1 motion (at default
+        // settings), and window size is used for scaling rotation (because it feels better than
+        // using the viewport size). Here, we set the values to the actual values of the minimap
+        // camera, which is what PanOrbitCameraPlugin would do.
+        viewport_size: minimap_camera.logical_viewport_size(),
+        window_size: Some(Vec2::new(primary_window.width(), primary_window.height())),
+        // Setting manual to true ensures PanOrbitCameraPlugin will not overwrite this resource
+        manual: true,
+    });
+}
+
+fn set_camera_viewports(
+    windows: Query<&Window>,
+    mut resize_events: EventReader<WindowResized>,
+    mut right_camera: Query<&mut Camera, With<MinimapCamera>>,
+) {
+    for resize_event in resize_events.iter() {
+        let window = windows.get(resize_event.window).unwrap();
+        let mut right_camera = right_camera.single_mut();
+        let size = window.resolution.physical_width() / 5;
+        right_camera.viewport = Some(Viewport {
+            physical_position: UVec2::new(window.resolution.physical_width() - size, 0),
+            physical_size: UVec2::new(size, size),
+            ..default()
+        });
+    }
+}

--- a/examples/render_to_texture.rs
+++ b/examples/render_to_texture.rs
@@ -1,6 +1,5 @@
 //! Demonstrates the ability to manually override which instance of PanOrbitCamera receives input
-//! events.
-//! The most obvious use case is when rendering to a texture/image instead of a window/viewport.
+//! events, which is necessary when rendering to a texture/image instead of a window/viewport.
 //!
 //! This example is based off Bevy's render_to_texture example.
 
@@ -158,10 +157,11 @@ fn setup(
 
     // Set up manual override of PanOrbitCamera. Note that this must run after PanOrbitCameraPlugin
     // is added, otherwise ActiveCameraData will be overwritten.
-    // Note: you probably want to update the `viewport_size` and `window_size` whenever they change.
+    // Note: you probably want to update the `viewport_size` and `window_size` whenever they change,
+    // I haven't done this here for simplicity.
     let primary_window = windows
         .get_single()
-        .expect("There is only ever one primary camera");
+        .expect("There is only ever one primary window");
     active_cam.set_if_neq(ActiveCameraData {
         // Set the entity to the entity ID of the camera you want to control. In this case, it's
         // the inner (first pass) cube that is rendered to the texture/image.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,11 @@ impl Plugin for PanOrbitCameraPlugin {
         app.insert_resource(ActiveCameraData::default())
             .add_systems(
                 Update,
-                (active_viewport_data, pan_orbit_camera)
+                (
+                    active_viewport_data
+                        .run_if(|active_cam: Res<ActiveCameraData>| !active_cam.manual),
+                    pan_orbit_camera,
+                )
                     .chain()
                     .in_set(PanOrbitCameraSystemSet),
             );
@@ -263,13 +267,29 @@ impl Default for PanOrbitCamera {
     }
 }
 
-// Tracks the camera entity that should be handling input events.
-// This enables having multiple cameras with different viewports or windows.
+/// Tracks which `PanOrbitCamera` is active (should handle input events), along with the window
+/// and viewport dimensions, which are used for scaling mouse motion.
+/// `PanOrbitCameraPlugin` manages this resource automatically, in order to support multiple
+/// viewports/windows. However, if this doesn't work for you, you can take over and manage it
+/// yourself, e.g. when you want to control a camera that is rendering to a texture.
 #[derive(Resource, Default, Debug, PartialEq)]
-struct ActiveCameraData {
-    entity: Option<Entity>,
-    viewport_size: Option<Vec2>,
-    window_size: Option<Vec2>,
+pub struct ActiveCameraData {
+    /// ID of the entity with `PanOrbitCamera` that will handle user input. In other words, this
+    /// is the camera that will move when you orbit/pan/zoom.
+    pub entity: Option<Entity>,
+    /// The viewport size. This is only used to scale the panning mouse motion. I recommend setting
+    /// this to the actual render target dimensions, and changing `PanOrbitCamera::pan_sensitivity`
+    /// to adjust the sensitivity if required.
+    pub viewport_size: Option<Vec2>,
+    /// The size of the window. This is only used to scale the orbit mouse motion. I recommend
+    /// setting this to actual dimensions of the window that you want to control the camera from,
+    /// and changing `PanOrbitCamera::orbit_sensitivity` to adjust the sensitivity if required.
+    pub window_size: Option<Vec2>,
+    /// Indicates to `PanOrbitCameraPlugin` that it should not update/overwrite this resource.
+    /// If you are manually updating this resource you should set this to `true`.
+    /// Note that setting this to `true` will effectively break multiple viewport/window support
+    /// unless you manually reimplement it.
+    pub manual: bool,
 }
 
 // Gathers data about the active viewport, i.e. the viewport the user is interacting with. This
@@ -283,12 +303,7 @@ fn active_viewport_data(
     other_windows: Query<&Window, Without<PrimaryWindow>>,
     orbit_cameras: Query<(Entity, &Camera, &PanOrbitCamera)>,
 ) {
-    // let mut new_resource: Option<ActiveCameraData> = None;
-    let mut new_resource = ActiveCameraData {
-        entity: None,
-        viewport_size: None,
-        window_size: None,
-    };
+    let mut new_resource = ActiveCameraData::default();
     let mut max_cam_order = 0;
 
     let mut has_input = false;
@@ -326,6 +341,7 @@ fn active_viewport_data(
                                 entity: Some(entity),
                                 viewport_size: camera.logical_viewport_size(),
                                 window_size: Some(Vec2::new(window.width(), window.height())),
+                                manual: false,
                             };
                             max_cam_order = camera.order;
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,8 +278,8 @@ pub struct ActiveCameraData {
     /// is the camera that will move when you orbit/pan/zoom.
     pub entity: Option<Entity>,
     /// The viewport size. This is only used to scale the panning mouse motion. I recommend setting
-    /// this to the actual render target dimensions, and changing `PanOrbitCamera::pan_sensitivity`
-    /// to adjust the sensitivity if required.
+    /// this to the actual render target dimensions (e.g. the image or viewport), and changing
+    /// `PanOrbitCamera::pan_sensitivity` to adjust the sensitivity if required.
     pub viewport_size: Option<Vec2>,
     /// The size of the window. This is only used to scale the orbit mouse motion. I recommend
     /// setting this to actual dimensions of the window that you want to control the camera from,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,9 @@ fn pan_orbit_camera(
         let mut scroll_pixel = 0.0;
         let mut orbit_button_changed = false;
 
+        // The reason we only skip getting input if the camera is inactive/disabled is because
+        // it might still be moving (lerping towards target values) when the user is not
+        // actively controlling it.
         if pan_orbit.enabled && active_cam.entity == Some(entity) {
             if util::orbit_pressed(&pan_orbit, &mouse_input, &key_input) {
                 rotation_move += mouse_delta * pan_orbit.orbit_sensitivity;


### PR DESCRIPTION
Adds ability to manage `ActiveCameraData` resource manually, which allows one to control cameras that don't render to a viewport (render to texture), or just generally allows forcing input from one window/viewport to be used for a specific camera.

This does not support multiple cameras that are controlled from different windows/viewports. The only way to have multiple cameras be controllable is to let the plugin handle `ActiveCameraData`.

Fixes #33 