### PR TITLE
Refactor input code

### DIFF
--- a/examples/touch/Cargo.lock
+++ b/examples/touch/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_panorbit_camera"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "bevy",
  "bevy_easings",

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,3 @@
-use crate::util;
 use crate::{ActiveCameraData, PanOrbitCamera};
 use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
 use bevy::input::touch::Touch;
@@ -34,9 +33,9 @@ pub fn mouse_tracker(
             let mut scroll_pixel = 0.0;
             let mut orbit_button_changed = false;
 
-            if util::orbit_pressed(pan_orbit, &mouse_input, &key_input) {
+            if orbit_pressed(pan_orbit, &mouse_input, &key_input) {
                 orbit += mouse_delta;
-            } else if util::pan_pressed(pan_orbit, &mouse_input, &key_input) {
+            } else if pan_pressed(pan_orbit, &mouse_input, &key_input) {
                 // Pan only if we're not rotating at the moment
                 pan += mouse_delta;
             }
@@ -53,8 +52,8 @@ pub fn mouse_tracker(
                 };
             }
 
-            if util::orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
-                || util::orbit_just_released(pan_orbit, &mouse_input, &key_input)
+            if orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
+                || orbit_just_released(pan_orbit, &mouse_input, &key_input)
             {
                 orbit_button_changed = true;
             }
@@ -134,4 +133,84 @@ pub fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTrack
         }
         _ => {}
     }
+}
+
+pub fn orbit_pressed(
+    pan_orbit: &PanOrbitCamera,
+    mouse_input: &Res<Input<MouseButton>>,
+    key_input: &Res<Input<KeyCode>>,
+) -> bool {
+    let is_pressed = pan_orbit
+        .modifier_orbit
+        .map_or(true, |modifier| key_input.pressed(modifier))
+        && mouse_input.pressed(pan_orbit.button_orbit);
+
+    is_pressed
+        && pan_orbit
+            .modifier_pan
+            .map_or(true, |modifier| !key_input.pressed(modifier))
+}
+
+pub fn orbit_just_pressed(
+    pan_orbit: &PanOrbitCamera,
+    mouse_input: &Res<Input<MouseButton>>,
+    key_input: &Res<Input<KeyCode>>,
+) -> bool {
+    let just_pressed = pan_orbit
+        .modifier_orbit
+        .map_or(true, |modifier| key_input.pressed(modifier))
+        && (mouse_input.just_pressed(pan_orbit.button_orbit));
+
+    just_pressed
+        && pan_orbit
+            .modifier_pan
+            .map_or(true, |modifier| !key_input.pressed(modifier))
+}
+
+pub fn orbit_just_released(
+    pan_orbit: &PanOrbitCamera,
+    mouse_input: &Res<Input<MouseButton>>,
+    key_input: &Res<Input<KeyCode>>,
+) -> bool {
+    let just_released = pan_orbit
+        .modifier_orbit
+        .map_or(true, |modifier| key_input.pressed(modifier))
+        && (mouse_input.just_released(pan_orbit.button_orbit));
+
+    just_released
+        && pan_orbit
+            .modifier_pan
+            .map_or(true, |modifier| !key_input.pressed(modifier))
+}
+
+pub fn pan_pressed(
+    pan_orbit: &PanOrbitCamera,
+    mouse_input: &Res<Input<MouseButton>>,
+    key_input: &Res<Input<KeyCode>>,
+) -> bool {
+    let is_pressed = pan_orbit
+        .modifier_pan
+        .map_or(true, |modifier| key_input.pressed(modifier))
+        && mouse_input.pressed(pan_orbit.button_pan);
+
+    is_pressed
+        && pan_orbit
+            .modifier_orbit
+            .map_or(true, |modifier| !key_input.pressed(modifier))
+}
+
+pub fn pan_just_pressed(
+    pan_orbit: &PanOrbitCamera,
+    mouse_input: &Res<Input<MouseButton>>,
+    key_input: &Res<Input<KeyCode>>,
+) -> bool {
+    let just_pressed = pan_orbit
+        .modifier_pan
+        .map_or(true, |modifier| key_input.pressed(modifier))
+        && (mouse_input.just_pressed(pan_orbit.button_pan));
+
+    just_pressed
+        && pan_orbit
+            .modifier_orbit
+            .map_or(true, |modifier| !key_input.pressed(modifier))
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,87 @@
+use crate::traits::Midpoint;
+use bevy::input::touch::Touch;
+use bevy::math::Vec2;
+use bevy::prelude::{Res, ResMut, Resource, Touches};
+use bevy::utils::HashMap;
+
+/// Store current and previous frame touch data
+#[derive(Resource, Default, Debug)]
+pub struct TouchTracker {
+    pub current_pressed: HashMap<u64, Touch>,
+    pub previous_pressed: HashMap<u64, Touch>,
+    pub curr_pressed: (Option<Touch>, Option<Touch>),
+    pub prev_pressed: (Option<Touch>, Option<Touch>),
+}
+
+impl TouchTracker {
+    /// Return orbit, pan, and zoom values based on touch data
+    pub fn calculate_movement(&self) -> (Vec2, Vec2, f32) {
+        let mut orbit = Vec2::ZERO;
+        let mut pan = Vec2::ZERO;
+        let mut zoom = 0.0;
+
+        // Only match when curr and prev have same number of touches, for simplicity.
+        // I did not notice any adverse behaviour as a result.
+        match (self.curr_pressed, self.prev_pressed) {
+            ((Some(curr), None), (Some(prev), None)) => {
+                let curr_pos = curr.position();
+                let prev_pos = prev.position();
+
+                orbit += curr_pos - prev_pos;
+            }
+            ((Some(curr1), Some(curr2)), (Some(prev1), Some(prev2))) => {
+                let curr1_pos = curr1.position();
+                let curr2_pos = curr2.position();
+                let prev1_pos = prev1.position();
+                let prev2_pos = prev2.position();
+
+                let curr_midpoint = curr1_pos.midpoint(curr2_pos);
+                let prev_midpoint = prev1_pos.midpoint(prev2_pos);
+                pan += curr_midpoint - prev_midpoint;
+
+                let curr_dist = curr1_pos.distance(curr2_pos);
+                let prev_dist = prev1_pos.distance(prev2_pos);
+                zoom += curr_dist - prev_dist;
+            }
+            _ => {}
+        }
+
+        (orbit, pan, zoom)
+    }
+}
+
+/// Read touch input and save it in TouchTracker resource for easy consumption by the main system
+pub fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTracker>) {
+    let pressed: Vec<&Touch> = touches.iter().collect();
+
+    match pressed.len() {
+        0 => {
+            touch_tracker.current_pressed.clear();
+            touch_tracker.previous_pressed.clear();
+
+            touch_tracker.curr_pressed = (None, None);
+            touch_tracker.prev_pressed = (None, None);
+        }
+        1 => {
+            let touch: &Touch = pressed.first().unwrap();
+            touch_tracker.previous_pressed = touch_tracker.current_pressed.clone();
+            touch_tracker.current_pressed.clear();
+            touch_tracker.current_pressed.insert(touch.id(), *touch);
+
+            touch_tracker.prev_pressed = touch_tracker.curr_pressed;
+            touch_tracker.curr_pressed = (Some(*touch), None);
+        }
+        2 => {
+            let touch1: &Touch = pressed.first().unwrap();
+            let touch2: &Touch = pressed.last().unwrap();
+            touch_tracker.previous_pressed = touch_tracker.current_pressed.clone();
+            touch_tracker.current_pressed.clear();
+            touch_tracker.current_pressed.insert(touch1.id(), *touch1);
+            touch_tracker.current_pressed.insert(touch2.id(), *touch2);
+
+            touch_tracker.prev_pressed = touch_tracker.curr_pressed;
+            touch_tracker.curr_pressed = (Some(*touch1), Some(*touch2));
+        }
+        _ => {}
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use crate::traits::Midpoint;
 
 #[derive(Resource, Default, Debug)]
-pub struct MouseTracker {
+pub struct MouseKeyTracker {
     pub orbit: Vec2,
     pub pan: Vec2,
     pub scroll_line: f32,
@@ -14,8 +14,8 @@ pub struct MouseTracker {
     pub orbit_button_changed: bool,
 }
 
-pub fn mouse_tracker(
-    mut camera_movement: ResMut<MouseTracker>,
+pub fn mouse_key_tracker(
+    mut camera_movement: ResMut<MouseKeyTracker>,
     mouse_input: Res<Input<MouseButton>>,
     key_input: Res<Input<KeyCode>>,
     mut mouse_motion: EventReader<MouseMotion>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+use std::f32::consts::{PI, TAU};
+
 use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
 use bevy::input::touch::Touch;
 use bevy::prelude::*;
 use bevy::render::camera::RenderTarget;
-use bevy::utils::HashMap;
 use bevy::window::{PrimaryWindow, WindowRef};
 #[cfg(feature = "bevy_egui")]
 use bevy_egui::EguiSet;
+
 #[cfg(feature = "bevy_egui")]
 pub use egui::EguiWantsFocus;
-use std::f32::consts::{PI, TAU};
 use traits::Midpoint;
 
 #[cfg(feature = "bevy_egui")]
@@ -375,8 +376,6 @@ fn active_viewport_data(
 /// Store current and previous frame touch data
 #[derive(Resource, Default, Debug)]
 struct TouchTracker {
-    pub current_pressed: HashMap<u64, Touch>,
-    pub previous_pressed: HashMap<u64, Touch>,
     pub curr_pressed: (Option<Touch>, Option<Touch>),
     pub prev_pressed: (Option<Touch>, Option<Touch>),
 }
@@ -424,29 +423,17 @@ fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTracker>)
 
     match pressed.len() {
         0 => {
-            touch_tracker.current_pressed.clear();
-            touch_tracker.previous_pressed.clear();
-
             touch_tracker.curr_pressed = (None, None);
             touch_tracker.prev_pressed = (None, None);
         }
         1 => {
             let touch: &Touch = pressed.first().unwrap();
-            touch_tracker.previous_pressed = touch_tracker.current_pressed.clone();
-            touch_tracker.current_pressed.clear();
-            touch_tracker.current_pressed.insert(touch.id(), *touch);
-
             touch_tracker.prev_pressed = touch_tracker.curr_pressed;
             touch_tracker.curr_pressed = (Some(*touch), None);
         }
         2 => {
             let touch1: &Touch = pressed.first().unwrap();
             let touch2: &Touch = pressed.last().unwrap();
-            touch_tracker.previous_pressed = touch_tracker.current_pressed.clone();
-            touch_tracker.current_pressed.clear();
-            touch_tracker.current_pressed.insert(touch1.id(), *touch1);
-            touch_tracker.current_pressed.insert(touch2.id(), *touch2);
-
             touch_tracker.prev_pressed = touch_tracker.curr_pressed;
             touch_tracker.curr_pressed = (Some(*touch1), Some(*touch2));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 use std::f32::consts::{PI, TAU};
 
 use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
-use bevy::input::touch::Touch;
 use bevy::prelude::*;
 use bevy::render::camera::RenderTarget;
 use bevy::window::{PrimaryWindow, WindowRef};
@@ -13,12 +12,14 @@ use bevy_egui::EguiSet;
 
 #[cfg(feature = "bevy_egui")]
 pub use egui::EguiWantsFocus;
+use input::TouchTracker;
 use traits::Midpoint;
 
 #[cfg(feature = "bevy_egui")]
 mod egui;
 mod traits;
 mod util;
+mod input;
 
 /// Bevy plugin that contains the systems for controlling `PanOrbitCamera` components.
 /// # Example
@@ -43,7 +44,7 @@ impl Plugin for PanOrbitCameraPlugin {
                 (
                     active_viewport_data
                         .run_if(|active_cam: Res<ActiveCameraData>| !active_cam.manual),
-                    touch_tracker,
+                    input::touch_tracker,
                     pan_orbit_camera,
                 )
                     .chain()
@@ -370,74 +371,6 @@ fn active_viewport_data(
 
     if has_input {
         active_cam.set_if_neq(new_resource);
-    }
-}
-
-/// Store current and previous frame touch data
-#[derive(Resource, Default, Debug)]
-struct TouchTracker {
-    pub curr_pressed: (Option<Touch>, Option<Touch>),
-    pub prev_pressed: (Option<Touch>, Option<Touch>),
-}
-
-impl TouchTracker {
-    /// Return orbit, pan, and zoom values based on touch data
-    fn calculate_movement(&self) -> (Vec2, Vec2, f32) {
-        let mut orbit = Vec2::ZERO;
-        let mut pan = Vec2::ZERO;
-        let mut zoom = 0.0;
-
-        // Only match when curr and prev have same number of touches, for simplicity.
-        // I did not notice any adverse behaviour as a result.
-        match (self.curr_pressed, self.prev_pressed) {
-            ((Some(curr), None), (Some(prev), None)) => {
-                let curr_pos = curr.position();
-                let prev_pos = prev.position();
-
-                orbit += curr_pos - prev_pos;
-            }
-            ((Some(curr1), Some(curr2)), (Some(prev1), Some(prev2))) => {
-                let curr1_pos = curr1.position();
-                let curr2_pos = curr2.position();
-                let prev1_pos = prev1.position();
-                let prev2_pos = prev2.position();
-
-                let curr_midpoint = curr1_pos.midpoint(curr2_pos);
-                let prev_midpoint = prev1_pos.midpoint(prev2_pos);
-                pan += curr_midpoint - prev_midpoint;
-
-                let curr_dist = curr1_pos.distance(curr2_pos);
-                let prev_dist = prev1_pos.distance(prev2_pos);
-                zoom += curr_dist - prev_dist;
-            }
-            _ => {}
-        }
-
-        (orbit, pan, zoom)
-    }
-}
-
-/// Read touch input and save it in TouchTracker resource for easy consumption by the main system
-fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTracker>) {
-    let pressed: Vec<&Touch> = touches.iter().collect();
-
-    match pressed.len() {
-        0 => {
-            touch_tracker.curr_pressed = (None, None);
-            touch_tracker.prev_pressed = (None, None);
-        }
-        1 => {
-            let touch: &Touch = pressed.first().unwrap();
-            touch_tracker.prev_pressed = touch_tracker.curr_pressed;
-            touch_tracker.curr_pressed = (Some(*touch), None);
-        }
-        2 => {
-            let touch1: &Touch = pressed.first().unwrap();
-            let touch2: &Touch = pressed.last().unwrap();
-            touch_tracker.prev_pressed = touch_tracker.curr_pressed;
-            touch_tracker.curr_pressed = (Some(*touch1), Some(*touch2));
-        }
-        _ => {}
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,18 @@
 
 use std::f32::consts::{PI, TAU};
 
-use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
+use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
 use bevy::render::camera::RenderTarget;
 use bevy::window::{PrimaryWindow, WindowRef};
 #[cfg(feature = "bevy_egui")]
 use bevy_egui::EguiSet;
 
-use crate::input::MouseTracker;
 #[cfg(feature = "bevy_egui")]
 pub use egui::EguiWantsFocus;
 use input::TouchTracker;
-use traits::Midpoint;
+
+use crate::input::MouseTracker;
 
 #[cfg(feature = "bevy_egui")]
 mod egui;
@@ -321,8 +321,8 @@ fn active_viewport_data(
 
     let mut has_input = false;
     for (entity, camera, pan_orbit) in orbit_cameras.iter() {
-        let input_just_activated = util::orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
-            || util::pan_just_pressed(pan_orbit, &mouse_input, &key_input)
+        let input_just_activated = input::orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
+            || input::pan_just_pressed(pan_orbit, &mouse_input, &key_input)
             || !scroll_events.is_empty()
             || (touches.iter_just_pressed().count() > 0
                 && touches.iter_just_pressed().count() == touches.iter().count());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use bevy_egui::EguiSet;
 pub use egui::EguiWantsFocus;
 use input::TouchTracker;
 
-use crate::input::MouseTracker;
+use crate::input::MouseKeyTracker;
 
 #[cfg(feature = "bevy_egui")]
 mod egui;
@@ -39,14 +39,14 @@ pub struct PanOrbitCameraPlugin;
 impl Plugin for PanOrbitCameraPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(ActiveCameraData::default())
-            .insert_resource(MouseTracker::default())
+            .insert_resource(MouseKeyTracker::default())
             .insert_resource(TouchTracker::default())
             .add_systems(
                 Update,
                 (
                     active_viewport_data
                         .run_if(|active_cam: Res<ActiveCameraData>| !active_cam.manual),
-                    input::mouse_tracker,
+                    input::mouse_key_tracker,
                     input::touch_tracker,
                     pan_orbit_camera,
                 )
@@ -380,7 +380,7 @@ fn active_viewport_data(
 /// Main system for processing input and converting to transformations
 fn pan_orbit_camera(
     active_cam: Res<ActiveCameraData>,
-    mouse_tracker: Res<MouseTracker>,
+    mouse_key_tracker: Res<MouseKeyTracker>,
     touch_tracker: Res<TouchTracker>,
     mut orbit_cameras: Query<(Entity, &mut PanOrbitCamera, &mut Transform, &mut Projection)>,
 ) {
@@ -462,13 +462,14 @@ fn pan_orbit_camera(
                 false => 1.0,
             };
 
-            orbit = (mouse_tracker.orbit + touch_orbit) * pan_orbit.orbit_sensitivity;
-            pan = (mouse_tracker.pan + touch_pan) * pan_orbit.pan_sensitivity;
-            scroll_line = mouse_tracker.scroll_line * zoom_direction * pan_orbit.zoom_sensitivity;
-            scroll_pixel = (mouse_tracker.scroll_pixel + touch_zoom)
+            orbit = (mouse_key_tracker.orbit + touch_orbit) * pan_orbit.orbit_sensitivity;
+            pan = (mouse_key_tracker.pan + touch_pan) * pan_orbit.pan_sensitivity;
+            scroll_line =
+                mouse_key_tracker.scroll_line * zoom_direction * pan_orbit.zoom_sensitivity;
+            scroll_pixel = (mouse_key_tracker.scroll_pixel + touch_zoom)
                 * zoom_direction
                 * pan_orbit.zoom_sensitivity;
-            orbit_button_changed = mouse_tracker.orbit_button_changed;
+            orbit_button_changed = mouse_key_tracker.orbit_button_changed;
         }
 
         // 2 - Process input into target alpha/beta, or focus, radius

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,5 @@
-use crate::PanOrbitCamera;
-use bevy::input::Input;
 use bevy::math::{Quat, Vec3};
-use bevy::prelude::{KeyCode, MouseButton, Res, Transform};
+use bevy::prelude::Transform;
 use bevy_easings::Lerp;
 
 const EPSILON: f32 = 0.001;
@@ -19,86 +17,6 @@ pub fn calculate_from_translation_and_focus(translation: Vec3, focus: Vec3) -> (
     };
     let beta = (comp_vec.y / radius).asin();
     (alpha, beta, radius)
-}
-
-pub fn orbit_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let is_pressed = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && mouse_input.pressed(pan_orbit.button_orbit);
-
-    is_pressed
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-pub fn orbit_just_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_pressed = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_pressed(pan_orbit.button_orbit));
-
-    just_pressed
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-pub fn orbit_just_released(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_released = pan_orbit
-        .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_released(pan_orbit.button_orbit));
-
-    just_released
-        && pan_orbit
-            .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-pub fn pan_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let is_pressed = pan_orbit
-        .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && mouse_input.pressed(pan_orbit.button_pan);
-
-    is_pressed
-        && pan_orbit
-            .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
-}
-
-pub fn pan_just_pressed(
-    pan_orbit: &PanOrbitCamera,
-    mouse_input: &Res<Input<MouseButton>>,
-    key_input: &Res<Input<KeyCode>>,
-) -> bool {
-    let just_pressed = pan_orbit
-        .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
-        && (mouse_input.just_pressed(pan_orbit.button_pan));
-
-    just_pressed
-        && pan_orbit
-            .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
 }
 
 /// Update `transform` based on alpha, beta, and the camera's focus and radius


### PR DESCRIPTION
Reorganises input-related code into `input` mod, to simplify the main system. This is a step towards separating out the orbit/pan/zoom logic from everything else, which may allow supporting an alternate implementation in the future. But even if that doesn't happen it's still an improvement to the overall code structure. There's more to do, but this is a good start.

Oh also this includes an update to the touch example's cargo lock file, for no reason other than I can't be bothered separating that change 😆 