### PR TITLE
Add 'roll' controls and custom 'up' vector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ the concept of 'up' and 'down' change, and so the above explanation changes acco
 
 ## Cargo Features
 
-- `bevy_egui` (optional): makes `PanOrbitCamera` ignore any input that `egui` uses
+- `bevy_egui` (optional): makes `PanOrbitCamera` ignore any input that `egui` uses, thus preventing moving the camera
+  when interacting with egui windows
 
 ## Version Compatibility
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,26 @@
 Bevy Pan/Orbit Camera provides orbit camera controls for Bevy Engine, designed with simplicity and flexibility in mind.
 Use it to quickly prototype, experiment, for model viewers, and more!
 
-Default controls:
+## Features:
+
+- Smoothed orbiting, panning, and zooming
+- Works with orthographic camera projection in addition to perspective
+- Customisable controls, sensitivity, and more
+- Touch support
+  - Currently 'beta' - please report any issues!
+- Works with multiple viewports and/or windows
+- Easy to control manually, e.g. for keyboard control or animation
+- Can control cameras that render to a texture
+- Supports the 'roll' axis and changing the 'up' vector, and thus controlling all 3 rotational axes
+  - Comes with caveats as explained in the documentation for `PanOrbitCamera.key_roll_left` /
+    `PanOrbitCamera.key_roll_right` and `PanOrbitCamera.base_transform`
+
+## Controls
+
+By default, you can only orbit, pan, and zoom. Optionally, you can enable the 'roll' axis, which modifies the 'up'
+vector of the camera. You can also set the 'up' vector manually - see `PanOrbitCamera.base_transform`.
+
+Default mouse controls:
 
 - Left Mouse - Orbit
 - Right Mouse - Pan
@@ -24,18 +43,10 @@ Touch controls:
 - One finger - Orbit
 - Two fingers - Pan
 - Pinch - Zoom
+- Two finger rotate - Roll (disabled by default)
 
-## Features:
-
-- Orbiting, panning and zooming
-- Smooth motion
-- Works with orthographic camera projection in addition to perspective
-- Customisable controls, sensitivity, and more
-- Touch support
-  - Currently 'beta' - please report any issues!
-- Works with multiple viewports and/or windows
-- Easy to control manually, e.g. for keyboard control or animation
-- Can control cameras that render to a texture
+Note: touch controls are currently not customisable. Please create an issue if you would like to customise the touch
+controls.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Use it to quickly prototype, experiment, for model viewers, and more!
 - Works with orthographic camera projection in addition to perspective
 - Customisable controls, sensitivity, and more
 - Touch support
-  - Currently 'beta' - please report any issues!
+    - Currently 'beta' - please report any issues!
 - Works with multiple viewports and/or windows
 - Easy to control manually, e.g. for keyboard control or animation
 - Can control cameras that render to a texture
 - Supports the 'roll' axis and changing the 'up' vector, and thus controlling all 3 rotational axes
-  - Comes with caveats as explained in the documentation for `PanOrbitCamera.key_roll_left` /
-    `PanOrbitCamera.key_roll_right` and `PanOrbitCamera.base_transform`
+    - Comes with caveats as explained in the documentation for `PanOrbitCamera.key_roll_left` /
+      `PanOrbitCamera.key_roll_right` and `PanOrbitCamera.base_transform`
 
 ## Controls
 
@@ -75,14 +75,22 @@ all the possible configuration options.
 
 ## What are `alpha` and `beta`?
 
-Think of this camera as rotating around a point, and always pointing at that point (the `focus`). The sideways rotation,
-i.e. the longitudinal rotation, is `alpha`, and the latitudinal rotation is `beta`. Both are measured in radians.
-If `alpha` and `beta` are both `0.0`, then the camera will be looking directly forwards (-Z direction). Increasing
-`alpha` will rotate around the `focus` to the right, and increasing `beta` will move the camera up and over the `focus`.
+Typically you don't need to worry about the inner workings of this plugin - the defaults work well and are suitable for
+most use cases. However, if you want to customise the behaviour, for example restricting the camera movement or
+adjusting sensitivity, you probably want to know what the `alpha` and `beta` values represent.
+
+While not strictly accurate, you can think of `alpha` as yaw and `beta` as tilt. More accurately, `alpha` represents the
+angle around the _global_ Y axis, and `beta` represents the angle around the _local_ X axis (i.e. the X axis after Y
+axis rotation has been applied). When both `alpha` and `beta` are `0.0`, the camera is pointing directly forward (-Z).
+Thus, increasing `alpha` orbits around to the right (counter clockwise if looking from above), and increasing `beta`
+orbits up and over (e.g. a `beta` value of 90 degrees (`PI / 2.0`) results in the camera looking straight down).
+
+Note that if you change the up vector either by enabling roll controls or changing `PanOrbitCamera.base_transform`,
+the concept of 'up' and 'down' change, and so the above explanation changes accordingly.
 
 ## Cargo Features
 
-- `bevy_egui`: makes PanOrbitCamera ignore input when interacting with egui widgets/windows
+- `bevy_egui` (optional): makes `PanOrbitCamera` ignore any input that `egui` uses
 
 ## Version Compatibility
 
@@ -96,7 +104,7 @@ If `alpha` and `beta` are both `0.0`, then the camera will be looking directly f
 
 - [Bevy Cheat Book](https://bevy-cheatbook.github.io): For providing an example that I started from
 - [babylon.js](https://www.babylonjs.com): I referenced their arc rotate camera for some of this
-- [bevy_pancam](https://github.com/johanhelsing/bevy_pancam): For the egui-related code
+- [bevy_pancam](https://github.com/johanhelsing/bevy_pancam): For the egui feature idea
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![A screen recording showing camera movement](https://user-images.githubusercontent.com/7709415/230715348-eb19d9a8-4826-4a73-a039-02cacdcb3dc9.gif "Demo of bevy_panorbit_camera")
 
-## What Is This?
+## Summary
 
 Bevy Pan/Orbit Camera provides orbit camera controls for Bevy Engine, designed with simplicity and flexibility in mind.
 Use it to quickly prototype, experiment, for model viewers, and more!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![docs.rs](https://docs.rs/bevy_panorbit_camera/badge.svg)](https://docs.rs/bevy_panorbit_camera)
 [![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
 
-<div align="center">
+<div style="text-align: center">
   <h1>Bevy Pan/Orbit Camera</h1>
 </div>
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,5 +1,11 @@
 //! Demonstrates all common configuration options,
 //! and how to modify them at runtime
+//!
+//! Controls:
+//!   Orbit: Middle click
+//!   Pan: Shift + Middle click
+//!   Zoom: Mousewheel
+//!   Roll: A (roll left) and D (roll right)
 
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
@@ -73,12 +79,18 @@ fn setup(
             modifier_pan: Some(KeyCode::ShiftLeft),
             // Reverse the zoom direction
             reversed_zoom: true,
+            // Enable roll in addition to orbit.
+            // Note: when enabling roll you probably also want to set `allow_upside_down` to `true`
+            // because upside down loses its meaning when you can roll freely.
+            key_roll_left: Some(KeyCode::A),
+            key_roll_right: Some(KeyCode::D),
             ..default()
         },
     ));
 }
 
-// Press 'T' to toggle the camera controls
+// This is how you can change config at runtime.
+// Press 'T' to toggle the camera controls.
 fn toggle_camera_controls_system(
     key_input: Res<Input<KeyCode>>,
     mut pan_orbit_query: Query<&mut PanOrbitCamera>,

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -84,6 +84,7 @@ fn setup(
             // because upside down loses its meaning when you can roll freely.
             key_roll_left: Some(KeyCode::A),
             key_roll_right: Some(KeyCode::D),
+            roll_sensitivity: 0.5,
             ..default()
         },
     ));

--- a/examples/alternate_up_vector.rs
+++ b/examples/alternate_up_vector.rs
@@ -1,4 +1,4 @@
-//! Demonstrates the simplest usage
+//! Demonstrates how to change the 'up' vector of the camera
 
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
@@ -46,8 +46,17 @@ fn setup(
             ..default()
         },
         PanOrbitCamera {
-            key_roll_left: Some(KeyCode::A),
-            key_roll_right: Some(KeyCode::D),
+            base_transform: Transform::from_rotation(Quat::from_rotation_arc(
+                Vec3::NEG_Y,
+                // This is the new 'up' vector, and it must be normalised before passing to
+                // `from_rotation_arc`. Alternatively you can set `base_transform` any way you want,
+                // e.g. from a rotation or an existing transform.
+                Vec3::new(0.2, -1.2, 0.2).normalize(),
+            )),
+            // When changing the 'up' vector, you probably also want to allow upside down, because
+            // 'upside down' is based upon the world 'up' vector (via alpha/beta values), and so
+            // doesn't make any sense when the up vector is some arbitrary direction.
+            allow_upside_down: true,
             ..default()
         },
     ));

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -45,10 +45,6 @@ fn setup(
             transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
             ..default()
         },
-        PanOrbitCamera {
-            key_roll_left: Some(KeyCode::A),
-            key_roll_right: Some(KeyCode::D),
-            ..default()
-        },
+        PanOrbitCamera::default(),
     ));
 }

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -52,7 +52,7 @@ fn setup(
             ..default()
         },
         PanOrbitCamera {
-            // Setting scale here will override the camera projection's  initial scale
+            // Setting scale here will override the camera projection's initial scale
             scale: Some(2.5),
             ..default()
         },

--- a/examples/render_to_texture.rs
+++ b/examples/render_to_texture.rs
@@ -1,6 +1,9 @@
 //! Demonstrates the ability to manually override which instance of PanOrbitCamera receives input
 //! events, which is necessary when rendering to a texture/image instead of a window/viewport.
 //!
+//! In this example, input controls the camera that is rendering the texture applied to the cube,
+//! rather than the main window camera.
+//!
 //! This example is based off Bevy's render_to_texture example.
 
 use std::f32::consts::PI;

--- a/examples/touch/src/lib.rs
+++ b/examples/touch/src/lib.rs
@@ -80,7 +80,13 @@ fn setup_scene(
             transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
             ..default()
         },
-        PanOrbitCamera::default(),
+        PanOrbitCamera {
+            // Enable roll for demonstration purposes. Typically you wouldn't want to enable
+            // this. See documentation for `key_roll_left` / `key_roll_right` and `base_transform`
+            // for more information.
+            touch_roll_enabled: true,
+            ..default()
+        },
     ));
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -132,9 +132,23 @@ impl TouchTracker {
                 // Roll
                 let prev_vec = prev2_pos - prev1_pos;
                 let curr_vec = curr2_pos - curr1_pos;
-                let prev_angle = prev_vec.angle_between(Vec2::NEG_Y);
-                let curr_angle = curr_vec.angle_between(Vec2::NEG_Y);
-                roll_angle = prev_angle - curr_angle;
+                let prev_angle_negy = prev_vec.angle_between(Vec2::NEG_Y);
+                let curr_angle_negy = curr_vec.angle_between(Vec2::NEG_Y);
+                let prev_angle_posy = prev_vec.angle_between(Vec2::Y);
+                let curr_angle_posy = curr_vec.angle_between(Vec2::Y);
+                let roll_angle_negy = prev_angle_negy - curr_angle_negy;
+                let roll_angle_posy = prev_angle_posy - curr_angle_posy;
+                // The angle between -1deg and +1deg is 358deg according to Vec2::angle_between,
+                // but we want the answer to be +2deg (or -2deg if swapped). Therefore, we calculate
+                // two angles - one from UP and one from DOWN, and use the smallest absolute value
+                // of the two. This is necessary to get a predictable result when the two touches
+                // swap sides (change from one being on the left and one being on the right to the
+                // other way round).
+                if roll_angle_negy.abs() < roll_angle_posy.abs() {
+                    roll_angle = roll_angle_negy;
+                } else {
+                    roll_angle = roll_angle_posy;
+                }
             }
             _ => {}
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@ use crate::{ActiveCameraData, PanOrbitCamera};
 use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
 use bevy::input::touch::Touch;
 use bevy::prelude::*;
+use std::f32::consts::TAU;
 
 use crate::traits::Midpoint;
 
@@ -11,6 +12,7 @@ pub struct MouseKeyTracker {
     pub pan: Vec2,
     pub scroll_line: f32,
     pub scroll_pixel: f32,
+    pub roll_angle: f32,
     pub orbit_button_changed: bool,
 }
 
@@ -31,8 +33,10 @@ pub fn mouse_key_tracker(
             let mut pan = Vec2::ZERO;
             let mut scroll_line = 0.0;
             let mut scroll_pixel = 0.0;
+            let mut roll_angle = 0.0;
             let mut orbit_button_changed = false;
 
+            // Orbit and pan
             if orbit_pressed(pan_orbit, &mouse_input, &key_input) {
                 orbit += mouse_delta;
             } else if pan_pressed(pan_orbit, &mouse_input, &key_input) {
@@ -40,6 +44,7 @@ pub fn mouse_key_tracker(
                 pan += mouse_delta;
             }
 
+            // Zoom
             for ev in scroll_events.read() {
                 let delta_scroll = ev.y;
                 match ev.unit {
@@ -52,6 +57,21 @@ pub fn mouse_key_tracker(
                 };
             }
 
+            // Roll
+            let roll_amount = TAU * 0.003;
+
+            if let Some(roll_left_key) = pan_orbit.key_roll_left {
+                if key_input.pressed(roll_left_key) {
+                    roll_angle -= roll_amount;
+                }
+            }
+            if let Some(roll_right_key) = pan_orbit.key_roll_right {
+                if key_input.pressed(roll_right_key) {
+                    roll_angle += roll_amount;
+                }
+            }
+
+            // Other
             if orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
                 || orbit_just_released(pan_orbit, &mouse_input, &key_input)
             {
@@ -62,6 +82,7 @@ pub fn mouse_key_tracker(
             camera_movement.pan = pan;
             camera_movement.scroll_line = scroll_line;
             camera_movement.scroll_pixel = scroll_pixel;
+            camera_movement.roll_angle = roll_angle;
             camera_movement.orbit_button_changed = orbit_button_changed;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,9 @@ pub struct PanOrbitCamera {
     /// The transform that all rotations and transforms are based upon.
     /// Typically this will always be equal to `Transform::IDENTITY`. It is used for the 'roll' axis
     /// (see `key_roll_left` and `key_roll_right`), but it can also be used to manually set the
-    /// vector the camera treats as 'up'.
+    /// vector the camera treats as 'up'. If you change this (or enable roll controls), you
+    /// probably also want to set `allow_upside_down` to `true`. Also note that alpha/beta limits
+    /// will be applied after `base_transform`, and thus may not act like you expect.
     /// Note that changing the translation or scale of this transform is currently not supported.
     /// Defaults to `Transform::IDENTITY`.
     pub base_transform: Transform,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,7 +581,7 @@ fn pan_orbit_camera(
             }
         }
 
-        // 2 - Adjust basis transform based on roll
+        // 2 - Adjust base transform based on roll
         pan_orbit
             .base_transform
             .rotate_axis(transform.local_z(), roll_angle);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,15 +4,39 @@ use std::ops::{Add, Sub};
 pub trait Midpoint {
     type V: Add + Sub;
 
+    /// Return the point exact halfway between two points
     fn midpoint(&self, other: Self::V) -> Self::V;
 }
 
 impl Midpoint for Vec2 {
     type V = Vec2;
 
-    fn midpoint(&self, other: Vec2) -> Vec2 {
+    fn midpoint(&self, other: Self::V) -> Self::V {
         let vec_to_other = other - *self;
         let half = vec_to_other / 2.0;
         *self + half
+    }
+}
+
+pub trait OptionalClamp {
+    type N: PartialOrd;
+
+    /// Clamp a value between two other values. The other values are optional. If both
+    /// `min` and `max` are `None`, then the return value is equal to `self`.
+    fn clamp_optional(&self, min: Option<Self::N>, max: Option<Self::N>) -> Self::N;
+}
+
+impl OptionalClamp for f32 {
+    type N = f32;
+
+    fn clamp_optional(&self, min: Option<Self::N>, max: Option<Self::N>) -> Self::N {
+        let mut new_val = *self;
+        if let Some(min) = min {
+            new_val = f32::max(new_val, min);
+        }
+        if let Some(max) = max {
+            new_val = f32::min(new_val, max);
+        }
+        new_val
     }
 }


### PR DESCRIPTION
closes #41 

Adds the ability to control the 3rd rotational axis (roll), in addition to yaw/tilt (alpha/beta). Adding the 3rd axis can make things weird, in that it changes what the camera treats as 'up' (the up vector). And once the up vector has changed, it's practically impossible to reset it back to default with just the camera controls. You have to reset it programmatically. For this reason, roll is disabled by default in both mouse/kb controls and touch controls.
Also, the concept of being 'upside down' makes no sense when you can change what 'up' means, and so `allow_upside_down` should typically be set to `true` when enabling roll or changing the up vector.

The roll control is implemented by introducing a 'base transform' upon which all other transformations are applied. By default, when roll is disabled, this base transform is identical to the world transform, i.e. `Transform::IDENTITY`. Changing the rotation of the base transform changes the 'up' vector. Changing the translation of it is not supported but theoretically it will effectively just change what 'zero pan' means, so isn't that useful. (Transform is used instead of a rotation like Quat or Mat3 because it provides useful methods.)

This PR also introduces a `touch_enabled` property which can be used to disable touch controls entirely (it's true by default). Disabling this may result in slightly better performance, but I haven't tested and I suspect the difference would be negligible in most cases.

* Add `key_roll_left` and `key_roll_right` properties, defaulting to `None` (i.e. roll disabled)
* Add `touch_enabled` and `touch_roll_enabled`, defaulting to `true` and `false` respectively
* Update touch example to enable roll
* Update advanced example to enable roll
* Add `alternate_up_vector` example
* Replace `apply_limits` util function with trait (more rusty!?)
* Various additions/improvements to comments/docs and minor code cleanup

Roll with keyboard controls:

https://github.com/Plonq/bevy_panorbit_camera/assets/7709415/b939f4e5-8e71-4b38-a179-8a5ef35ec2f5

Roll with touch controls:

https://github.com/Plonq/bevy_panorbit_camera/assets/7709415/9ebccc96-26c5-4a47-86d7-dd4f3c71ed34


