### PR TITLE
Framerate independence for 'roll' controls

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -84,7 +84,7 @@ fn setup(
             // because upside down loses its meaning when you can roll freely.
             key_roll_left: Some(KeyCode::A),
             key_roll_right: Some(KeyCode::D),
-            // roll_sensitivity: 0.5,
+            roll_sensitivity: 0.5,
             ..default()
         },
     ));

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -84,7 +84,7 @@ fn setup(
             // because upside down loses its meaning when you can roll freely.
             key_roll_left: Some(KeyCode::A),
             key_roll_right: Some(KeyCode::D),
-            roll_sensitivity: 0.5,
+            // roll_sensitivity: 0.5,
             ..default()
         },
     ));

--- a/src/input.rs
+++ b/src/input.rs
@@ -260,3 +260,12 @@ pub fn pan_just_pressed(
             .modifier_orbit
             .map_or(true, |modifier| !key_input.pressed(modifier))
 }
+
+pub fn roll_just_pressed(pan_orbit: &PanOrbitCamera, key_input: &Res<Input<KeyCode>>) -> bool {
+    pan_orbit
+        .key_roll_left
+        .map_or(false, |key| key_input.just_pressed(key))
+        || pan_orbit
+            .key_roll_right
+            .map_or(false, |key| key_input.just_pressed(key))
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,6 +16,7 @@ pub struct MouseKeyTracker {
     pub orbit_button_changed: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn mouse_key_tracker(
     mut camera_movement: ResMut<MouseKeyTracker>,
     mouse_input: Res<Input<MouseButton>>,
@@ -24,6 +25,7 @@ pub fn mouse_key_tracker(
     mut scroll_events: EventReader<MouseWheel>,
     active_cam: Res<ActiveCameraData>,
     orbit_cameras: Query<&PanOrbitCamera>,
+    time: Res<Time>,
 ) {
     // Always consume event reader events to prevent them building up and causing spikes
     let mouse_delta = mouse_motion.read().map(|event| event.delta).sum::<Vec2>();
@@ -57,7 +59,7 @@ pub fn mouse_key_tracker(
             scroll_pixel += scroll_pixel_delta;
 
             // Roll
-            let roll_amount = TAU * 0.003;
+            let roll_amount = TAU * 0.3 * time.delta_seconds();
             if let Some(roll_left_key) = pan_orbit.key_roll_left {
                 if key_input.pressed(roll_left_key) {
                     roll_angle -= roll_amount;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,6 +411,7 @@ fn active_viewport_data(
     for (entity, camera, pan_orbit) in orbit_cameras.iter() {
         let input_just_activated = input::orbit_just_pressed(pan_orbit, &mouse_input, &key_input)
             || input::pan_just_pressed(pan_orbit, &mouse_input, &key_input)
+            || input::roll_just_pressed(pan_orbit, &key_input)
             || !scroll_events.is_empty()
             || (touches.iter_just_pressed().count() > 0
                 && touches.iter_just_pressed().count() == touches.iter().count());


### PR DESCRIPTION
Fixes #46 

Makes the 'roll' controls framerate independent.
Also fixes bug where you have to click once before rolling worked.

https://github.com/Plonq/bevy_panorbit_camera/issues/48 is still a problem but will deal with that separately.