### PR TITLE
Remove built-in roll controls

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -5,7 +5,6 @@
 //!   Orbit: Middle click
 //!   Pan: Shift + Middle click
 //!   Zoom: Mousewheel
-//!   Roll: A (roll left) and D (roll right)
 
 use bevy::prelude::*;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
@@ -79,12 +78,6 @@ fn setup(
             modifier_pan: Some(KeyCode::ShiftLeft),
             // Reverse the zoom direction
             reversed_zoom: true,
-            // Enable roll in addition to orbit.
-            // Note: when enabling roll you probably also want to set `allow_upside_down` to `true`
-            // because upside down loses its meaning when you can roll freely.
-            key_roll_left: Some(KeyCode::A),
-            key_roll_right: Some(KeyCode::D),
-            roll_sensitivity: 0.5,
             ..default()
         },
     ));

--- a/examples/roll_axis.rs
+++ b/examples/roll_axis.rs
@@ -1,0 +1,81 @@
+//! Demonstrates how to 'roll' the camera, thus control the 3rd axis of rotation
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use std::f32::consts::TAU;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, roll_controls)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // Camera
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+            ..default()
+        },
+        PanOrbitCamera {
+            // Changing the up vector (which rolling does) changes what 'up' means, so you likely
+            // want to allow upside down when rolling.
+            allow_upside_down: true,
+            ..default()
+        },
+    ));
+}
+
+/// Use left/right arrow keys to roll the camera
+fn roll_controls(
+    mut pan_orbit_q: Query<(&mut PanOrbitCamera, &Transform)>,
+    time: Res<Time>,
+    key_input: Res<Input<KeyCode>>,
+) {
+    if let Ok((mut pan_orbit, transform)) = pan_orbit_q.get_single_mut() {
+        let mut roll_angle = 0.0;
+        let roll_amount = TAU / 3.0 * time.delta_seconds();
+        if key_input.pressed(KeyCode::Left) {
+            roll_angle -= roll_amount;
+        }
+        if key_input.pressed(KeyCode::Right) {
+            roll_angle += roll_amount;
+        }
+        // Rotate the base transform by the roll amount around its current 'look' axis
+        pan_orbit
+            .base_transform
+            .rotate_axis(transform.local_z(), roll_angle);
+        // Whenever controlling the camera manually you must make it force update every frame
+        pan_orbit.force_update = true;
+    }
+}

--- a/examples/touch/Cargo.lock
+++ b/examples/touch/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_panorbit_camera"
-version = "0.11.1"
+version = "0.12.1"
 dependencies = [
  "bevy",
  "bevy_easings",

--- a/examples/touch/src/lib.rs
+++ b/examples/touch/src/lib.rs
@@ -80,13 +80,7 @@ fn setup_scene(
             transform: Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
             ..default()
         },
-        PanOrbitCamera {
-            // Enable roll for demonstration purposes. Typically you wouldn't want to enable
-            // this. See documentation for `key_roll_left` / `key_roll_right` and `base_transform`
-            // for more information.
-            touch_roll_enabled: true,
-            ..default()
-        },
+        PanOrbitCamera::default(),
     ));
 }
 


### PR DESCRIPTION
Closes #48 

As explained in #48, having built-in roll controls has issues. First, having keyboard-only controls is ambiguous where there are multiple cameras - which one to control? Secondly, unlike orbit/pan, there are no obvious/intuitive roll controls. Rolling by moving the mouse feels weird, and using keyboard is a bit clunky and not as precise.
Additionally, rolling the camera is most likely a very uncommon use case, because it modifies the up vector which can result in weird perspectives and confusion. It is also practically impossible to get the up vector back to the world 'up' with just the camera controls themselves - you have to manually reset it.

For these reasons, I've decided to remove the built-in roll controls, and let anyone that wants to roll the camera do so if they wish. This puts the responsibility of choosing the control scheme on the user, which makes it more flexible, and it avoids the 'active cam' problem described above because the choice of which camera to control is also up to the user (note: you can choose to use the 'active cam' if you wish and deal with the same issues I described).
The one downside to this is that the touch controls for roll were quite intuitive and there wasn't really anything wrong with them. And re-implementing the touch gestures requires more code than simply checking a key code. But it doesn't make sense to keep the touch controls only.

I have added a `roll_axis` example to demonstrate how to roll the camera.