### PR TITLE
Remove `scale` field from `PanOrbitCamera`

### DIFF
--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -1,7 +1,10 @@
 //! Demonstrates usage with an orthographic camera
 
-use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
+use bevy::{
+    input::{keyboard::KeyboardInput, ButtonState},
+    prelude::*,
+};
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 
 fn main() {
@@ -9,6 +12,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
+        .add_systems(Update, switch_projection)
         .run();
 }
 
@@ -17,6 +21,17 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // help
+    commands.spawn(TextBundle {
+        text: Text {
+            sections: vec![TextSection {
+                value: "Press R to switch projection".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        ..default()
+    });
     // Ground
     commands.spawn(PbrBundle {
         mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
@@ -42,18 +57,29 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3dBundle {
-            // Put the camera further away so clipping is less likely
-            transform: Transform::from_translation(Vec3::new(0.0, 5.5, 15.0)),
+            transform: Transform::from_translation(Vec3::new(0.0, 1.5, 6.0)),
             projection: Projection::Orthographic(OrthographicProjection {
-                scaling_mode: ScalingMode::FixedVertical(2.0),
+                scaling_mode: ScalingMode::FixedVertical(1.0),
                 ..default()
             }),
             ..default()
         },
-        PanOrbitCamera {
-            // Setting scale here will override the camera projection's initial scale
-            scale: Some(2.5),
-            ..default()
-        },
+        PanOrbitCamera::default(),
     ));
+}
+
+fn switch_projection(
+    mut next_projection: Local<Projection>,
+    mut keyboard_events: EventReader<KeyboardInput>,
+    mut camera_query: Query<(&mut PanOrbitCamera, &mut Projection)>,
+) {
+    for event in keyboard_events.read() {
+        if event.key_code == KeyCode::KeyR && event.state == ButtonState::Pressed {
+            let Ok((mut camera, mut projection)) = camera_query.get_single_mut() else {
+                return;
+            };
+            std::mem::swap(&mut *next_projection, &mut *projection);
+            camera.force_update = true;
+        }
+    }
 }

--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -1,10 +1,7 @@
 //! Demonstrates usage with an orthographic camera
 
+use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
-use bevy::{
-    input::{keyboard::KeyboardInput, ButtonState},
-    prelude::*,
-};
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 
 fn main() {
@@ -70,16 +67,14 @@ fn setup(
 
 fn switch_projection(
     mut next_projection: Local<Projection>,
-    mut keyboard_events: EventReader<KeyboardInput>,
+    key_input: Res<ButtonInput<KeyCode>>,
     mut camera_query: Query<(&mut PanOrbitCamera, &mut Projection)>,
 ) {
-    for event in keyboard_events.read() {
-        if event.key_code == KeyCode::KeyR && event.state == ButtonState::Pressed {
-            let Ok((mut camera, mut projection)) = camera_query.get_single_mut() else {
-                return;
-            };
-            std::mem::swap(&mut *next_projection, &mut *projection);
-            camera.force_update = true;
-        }
+    if key_input.just_pressed(KeyCode::KeyR) {
+        let Ok((mut camera, mut projection)) = camera_query.get_single_mut() else {
+            return;
+        };
+        std::mem::swap(&mut *next_projection, &mut *projection);
+        camera.force_update = true;
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,12 +21,18 @@ pub fn calculate_from_translation_and_focus(translation: Vec3, focus: Vec3) -> (
 pub fn update_orbit_transform(
     alpha: f32,
     beta: f32,
-    radius: f32,
+    mut radius: f32,
     focus: Vec3,
     transform: &mut Transform,
+    projection: &mut Projection,
     basis: &Transform,
 ) {
     let mut new_transform = *basis;
+    if let Projection::Orthographic(ref mut p) = *projection {
+        p.scale = radius;
+        // (near + far) / 2.0 ensures that objects near `focus` are not clipped
+        radius = (p.near + p.far) / 2.0;
+    }
     new_transform.rotation *= Quat::from_rotation_y(alpha) * Quat::from_rotation_x(-beta);
     new_transform.translation += focus + new_transform.rotation * Vec3::new(0.0, 0.0, radius);
     *transform = new_transform;


### PR DESCRIPTION
I've added an example of switch projection to the orthographic example

https://github.com/Plonq/bevy_panorbit_camera/assets/35809384/8e9dc3fc-e9f0-4549-9cb6-63fbedac039c

