### PR TITLE
Fix flicker in orthographic example

### DIFF
--- a/examples/orthographic.rs
+++ b/examples/orthographic.rs
@@ -2,14 +2,14 @@
 
 use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
-use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin, PanOrbitCameraSystemSet};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, switch_projection)
+        .add_systems(Update, switch_projection.before(PanOrbitCameraSystemSet))
         .run();
 }
 


### PR DESCRIPTION
Switching from orthographic to perspective sometimes causes a flicker (1 frame by the looks of it). Not 100% reproducible, but I believe the problem is caused when the projection changes after PanOrbitCameraSystemSet runs, so I've updated the example to always switch before it runs.