### PR TITLE
71 movement stops if mouse over egui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,6 @@ impl Plugin for PanOrbitCameraPlugin {
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct PanOrbitCameraSystemSet;
 
-/// Base system set to allow ordering of `PanOrbitCamera`
-#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
-pub struct InputSystemSet;
-
 /// Tags an entity as capable of panning and orbiting, and provides a way to configure the
 /// camera's behaviour and controls.
 /// The entity must have `Transform` and `Projection` components. Typically you would add a


### PR DESCRIPTION
When egui feature enabled, instead of not running any of the orbit cam systems when egui 'wants focus', only skip getting input from the user. This fixes the camera stopping moving instantly if you hover over an egui window and release the the mouse buttons).

Fixes #71 


https://github.com/Plonq/bevy_panorbit_camera/assets/7709415/4878ddc3-c88d-40a8-8e3d-6cdbfa32abc7

