### PR TITLE
Implement workaround for egui issue with panels

### DIFF
--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -4,25 +4,18 @@
 use bevy::ecs::event::EventUpdateSignal;
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_panorbit_camera::{EguiWantsFocus, PanOrbitCamera, PanOrbitCameraPlugin};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
-        // .insert_resource(EguiWantsFocus {
-        //     include_hover: true,
-        //     ..default()
-        // })
         .add_plugins(EguiPlugin)
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (draw_file_tree, draw_title_bar, ui_example_system).chain(),
-        );
+        .add_systems(Update, ui_example_system);
 
     // Make Bevy drop unconsumed events every frame to prevent weird behaviour when moving mouse
-    // out of an egui window immediately after scrolling (zooming)
+    // out of an egui window right after scrolling (zooming)
     // See: https://bevyengine.org/news/bevy-0-13/#events-live-longer
     app.world.remove_resource::<EventUpdateSignal>();
 
@@ -70,51 +63,4 @@ fn ui_example_system(mut contexts: EguiContexts) {
     egui::Window::new("Hello").show(contexts.ctx_mut(), |ui| {
         ui.label("world");
     });
-}
-
-pub fn draw_title_bar(mut contexts: EguiContexts) {
-    egui::TopBottomPanel::top("title_bar").show(contexts.ctx_mut(), |ui| {
-        ui.visuals_mut().button_frame = false;
-        ui.horizontal(|ui| {
-            ui.menu_button("File", |ui| {
-                let _ = ui.button("Open").clicked();
-            });
-            ui.separator();
-            ui.menu_button("View", |ui| {
-                let mut test = false;
-                ui.checkbox(&mut test, "Checkbox A");
-                ui.checkbox(&mut test, "Checkbox B");
-            });
-        });
-    });
-}
-
-pub fn draw_file_tree(mut contexts: EguiContexts) {
-    egui::SidePanel::left("file_tree")
-        .default_width(300.0)
-        .max_width(500.0)
-        .show(contexts.ctx_mut(), |ui| {
-            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
-                egui::CollapsingHeader::new("Very Long Folder Name To Force Scroll A").show(
-                    ui,
-                    |ui| {
-                        ui.add(
-                            egui::Label::new("Very Long File Name To Force Scroll A")
-                                .selectable(false)
-                                .sense(egui::Sense::click()),
-                        );
-                        ui.add(
-                            egui::Label::new("Very Long File Name To Force Scroll B")
-                                .selectable(false)
-                                .sense(egui::Sense::click()),
-                        );
-                    },
-                );
-                ui.add(
-                    egui::Label::new("Very Long File Name To Force Scroll C")
-                        .selectable(false)
-                        .sense(egui::Sense::click()),
-                );
-            });
-        });
 }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -4,18 +4,25 @@
 use bevy::ecs::event::EventUpdateSignal;
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use bevy_panorbit_camera::{EguiWantsFocus, PanOrbitCamera, PanOrbitCameraPlugin};
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
+        // .insert_resource(EguiWantsFocus {
+        //     include_hover: true,
+        //     ..default()
+        // })
         .add_plugins(EguiPlugin)
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, ui_example_system);
+        .add_systems(
+            Update,
+            (draw_file_tree, draw_title_bar, ui_example_system).chain(),
+        );
 
     // Make Bevy drop unconsumed events every frame to prevent weird behaviour when moving mouse
-    // out of an egui window right after scrolling (zooming)
+    // out of an egui window immediately after scrolling (zooming)
     // See: https://bevyengine.org/news/bevy-0-13/#events-live-longer
     app.world.remove_resource::<EventUpdateSignal>();
 
@@ -63,4 +70,51 @@ fn ui_example_system(mut contexts: EguiContexts) {
     egui::Window::new("Hello").show(contexts.ctx_mut(), |ui| {
         ui.label("world");
     });
+}
+
+pub fn draw_title_bar(mut contexts: EguiContexts) {
+    egui::TopBottomPanel::top("title_bar").show(contexts.ctx_mut(), |ui| {
+        ui.visuals_mut().button_frame = false;
+        ui.horizontal(|ui| {
+            ui.menu_button("File", |ui| {
+                let _ = ui.button("Open").clicked();
+            });
+            ui.separator();
+            ui.menu_button("View", |ui| {
+                let mut test = false;
+                ui.checkbox(&mut test, "Checkbox A");
+                ui.checkbox(&mut test, "Checkbox B");
+            });
+        });
+    });
+}
+
+pub fn draw_file_tree(mut contexts: EguiContexts) {
+    egui::SidePanel::left("file_tree")
+        .default_width(300.0)
+        .max_width(500.0)
+        .show(contexts.ctx_mut(), |ui| {
+            egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
+                egui::CollapsingHeader::new("Very Long Folder Name To Force Scroll A").show(
+                    ui,
+                    |ui| {
+                        ui.add(
+                            egui::Label::new("Very Long File Name To Force Scroll A")
+                                .selectable(false)
+                                .sense(egui::Sense::click()),
+                        );
+                        ui.add(
+                            egui::Label::new("Very Long File Name To Force Scroll B")
+                                .selectable(false)
+                                .sense(egui::Sense::click()),
+                        );
+                    },
+                );
+                ui.add(
+                    egui::Label::new("Very Long File Name To Force Scroll C")
+                        .selectable(false)
+                        .sense(egui::Sense::click()),
+                );
+            });
+        });
 }

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -46,6 +46,9 @@ pub fn check_egui_wants_focus(
         }
         value
     });
-    wants_focus.prev = wants_focus.curr;
-    wants_focus.curr = new_wants_focus;
+    let new_res = EguiWantsFocus {
+        prev: wants_focus.curr,
+        curr: new_wants_focus,
+    };
+    wants_focus.set_if_neq(new_res);
 }

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -15,7 +15,11 @@ pub struct EguiWantsFocus {
     pub curr: bool,
     /// When true, just hovering over an egui panel/window will prevent PanOrbitCamera
     /// from reacting to input events. This is an optional, and hopefully temporary,
-    /// workaround to this issue: https://github.com/Plonq/bevy_panorbit_camera/issues/75
+    /// workaround to this issue: https://github.com/Plonq/bevy_panorbit_camera/issues/75.
+    /// Note that this will prevent PanOrbitCamera using reacting to input whenever the cursor
+    /// is over an egui area, even if you're in the middle of dragging to rotate, so only use
+    /// this if you use egui Panels (as opposed to Windows). If you use Windows exclusively
+    /// then no workaround is required.
     pub include_hover: bool,
 }
 

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -7,35 +7,31 @@ use bevy::prelude::*;
 /// egui window, Context::wants_pointer_input() still returns false once before returning
 /// true. If the camera stops taking input only when it returns false, there's one frame
 /// where both egui and the camera are using the input events, which is not desirable.
+///
+/// This is re-exported in case it's useful. I recommend only using input events if both
+/// `prev` and `curr` are false.
 #[derive(Resource, PartialEq, Eq, Default)]
 pub struct EguiWantsFocus {
     /// Whether egui wanted focus on the previous frame
     pub prev: bool,
     /// Whether egui wants focus on the current frame
     pub curr: bool,
-    /// When true, just hovering over an egui panel/window will prevent PanOrbitCamera
-    /// from reacting to input events. This is an optional, and hopefully temporary,
-    /// workaround to this issue: https://github.com/Plonq/bevy_panorbit_camera/issues/75.
-    /// Note that this will prevent PanOrbitCamera using reacting to input whenever the cursor
-    /// is over an egui area, even if you're in the middle of dragging to rotate, so only use
-    /// this if you use egui Panels (as opposed to Windows). If you use Windows exclusively
-    /// then no workaround is required.
-    pub include_hover: bool,
 }
 
-impl EguiWantsFocus {
-    /// Creates `EguiWantsFocus` with `include_hover` set to `true`
-    pub fn include_hover() -> Self {
-        EguiWantsFocus {
-            include_hover: true,
-            ..default()
-        }
-    }
-}
+/// When true, just hovering over an egui panel/window will prevent PanOrbitCamera
+/// from reacting to input events. This is an optional, and hopefully temporary,
+/// workaround to this issue: https://github.com/Plonq/bevy_panorbit_camera/issues/75.
+/// Note that this will prevent PanOrbitCamera using reacting to input whenever the cursor
+/// is over an egui area, even if you're in the middle of dragging to rotate, so only use
+/// this if you use egui Panels (as opposed to Windows). If you use Windows exclusively
+/// then no workaround is required.
+#[derive(Resource, PartialEq, Eq, Default)]
+pub struct EguiFocusIncludesHover(pub bool);
 
 pub fn check_egui_wants_focus(
     mut contexts: bevy_egui::EguiContexts,
     mut wants_focus: ResMut<EguiWantsFocus>,
+    include_hover: Res<EguiFocusIncludesHover>,
     windows: Query<Entity, With<Window>>,
 ) {
     // The window that the user is interacting with and the window that contains the egui context
@@ -45,7 +41,7 @@ pub fn check_egui_wants_focus(
     let new_wants_focus = windows.iter().any(|window| {
         let ctx = contexts.ctx_for_window_mut(window);
         let mut value = ctx.wants_pointer_input() || ctx.wants_keyboard_input();
-        if wants_focus.include_hover {
+        if include_hover.0 {
             value |= ctx.is_pointer_over_area()
         }
         value

--- a/src/egui.rs
+++ b/src/egui.rs
@@ -23,6 +23,16 @@ pub struct EguiWantsFocus {
     pub include_hover: bool,
 }
 
+impl EguiWantsFocus {
+    /// Creates `EguiWantsFocus` with `include_hover` set to `true`
+    pub fn include_hover() -> Self {
+        EguiWantsFocus {
+            include_hover: true,
+            ..default()
+        }
+    }
+}
+
 pub fn check_egui_wants_focus(
     mut contexts: bevy_egui::EguiContexts,
     mut wants_focus: ResMut<EguiWantsFocus>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use bevy::window::{PrimaryWindow, WindowRef};
 use bevy_egui::EguiSet;
 
 #[cfg(feature = "bevy_egui")]
-pub use crate::egui::EguiWantsFocus;
+pub use crate::egui::{EguiFocusIncludesHover, EguiWantsFocus};
 use crate::input::{mouse_key_tracker, MouseKeyTracker};
 pub use crate::touch::TouchControls;
 use crate::touch::{touch_tracker, TouchGestures, TouchTracker};
@@ -62,12 +62,14 @@ impl Plugin for PanOrbitCameraPlugin {
 
         #[cfg(feature = "bevy_egui")]
         {
-            app.init_resource::<EguiWantsFocus>().add_systems(
-                PostUpdate,
-                egui::check_egui_wants_focus
-                    .after(EguiSet::InitContexts)
-                    .before(PanOrbitCameraSystemSet),
-            );
+            app.init_resource::<EguiWantsFocus>()
+                .init_resource::<EguiFocusIncludesHover>()
+                .add_systems(
+                    PostUpdate,
+                    egui::check_egui_wants_focus
+                        .after(EguiSet::InitContexts)
+                        .before(PanOrbitCameraSystemSet),
+                );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+use bevy::ecs::system::Command;
 use std::f32::consts::{PI, TAU};
 
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
 use bevy::render::camera::RenderTarget;
+use bevy::transform::TransformSystem;
 use bevy::window::{PrimaryWindow, WindowRef};
 #[cfg(feature = "bevy_egui")]
 use bevy_egui::EguiSet;
@@ -44,7 +46,7 @@ impl Plugin for PanOrbitCameraPlugin {
             .init_resource::<MouseKeyTracker>()
             .init_resource::<TouchTracker>()
             .add_systems(
-                Update,
+                PostUpdate,
                 (
                     (
                         active_viewport_data
@@ -55,13 +57,14 @@ impl Plugin for PanOrbitCameraPlugin {
                     pan_orbit_camera,
                 )
                     .chain()
-                    .in_set(PanOrbitCameraSystemSet),
+                    .in_set(PanOrbitCameraSystemSet)
+                    .before(TransformSystem::TransformPropagate),
             );
 
         #[cfg(feature = "bevy_egui")]
         {
             app.init_resource::<EguiWantsFocus>().add_systems(
-                Update,
+                PostUpdate,
                 egui::check_egui_wants_focus
                     .after(EguiSet::InitContexts)
                     .before(PanOrbitCameraSystemSet),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-use bevy::ecs::system::Command;
 use std::f32::consts::{PI, TAU};
 
 use bevy::input::mouse::MouseWheel;


### PR DESCRIPTION
Implements an optional and imperfect workaround for https://github.com/Plonq/bevy_panorbit_camera/issues/75

To use the workaround:

```rust
// Insert this resource
.insert_resource(EguiFocusIncludesHover(true))
// Before this plugin
.add_plugins(PanOrbitCameraPlugin)
```

The reason it is imperfect is that moving the mouse over any egui panel will block all input from panorbit camera, even if you are already dragging (e.g. to rotate).

I've also moved the panorbit systems into `PostUpdate` to avoid potential race conditions depending on how systems are scheduled.