### PR TITLE
Fix egui focus edge cases

### DIFF
--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -54,7 +54,9 @@ fn setup(
 }
 
 fn ui_example_system(mut contexts: EguiContexts) {
-    egui::Window::new("Hello").show(contexts.ctx_mut(), |ui| {
-        ui.label("world");
-    });
+    egui::Window::new("Hello")
+        .movable(false)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.label("world");
+        });
 }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -54,9 +54,19 @@ fn setup(
 }
 
 fn ui_example_system(mut contexts: EguiContexts) {
-    egui::Window::new("Hello")
+    egui::SidePanel::left("left_panel")
+        .resizable(true)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.label("Left resizeable panel");
+        });
+
+    egui::Window::new("Movable Window").show(contexts.ctx_mut(), |ui| {
+        ui.label("Hello world");
+    });
+
+    egui::Window::new("Immovable Window")
         .movable(false)
         .show(contexts.ctx_mut(), |ui| {
-            ui.label("world");
+            ui.label("Hello world");
         });
 }


### PR DESCRIPTION
- When starting to orbit, this continue to work even when the pointer move to over a egui window/area
- When the mouse click and drag operation start in an egui window/area the camera does not start to orbit when getting out of the area and in the viewport