### PR TITLE
fix: update to latest bevy_egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bevy_egui = ["dep:bevy_egui"]
 bevy = { version = "0.14", default-features = false, features = [
     "bevy_render",
 ] }
-bevy_egui = { version = "0.29", optional = true, default-features = false }
+bevy_egui = { version = "0.30", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = { version = "0.14" }


### PR DESCRIPTION
resolves a compatibility issue with:

`bevy-inspector-egui = "0.27"`