### PR TITLE
Add bounds to Focus in line with other movement options

### DIFF
--- a/examples/focus_bounds.rs
+++ b/examples/focus_bounds.rs
@@ -1,0 +1,55 @@
+//! Demonstrates how to keep the camera's focus inside a shape.
+
+use bevy::{color::palettes::css::WHITE, prelude::*};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, show_bounds)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // Cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    commands.spawn((
+        Transform::from_translation(Vec3::new(0.0, 1.5, 5.0)),
+        PanOrbitCamera {
+            // Shape can take Cuboid or Sphere
+            focus_bounds_shape: Some(Cuboid::new(1.0, 1.0, 1.0).into()),
+            // Move the origin of the shape
+            focus_bounds_origin: Vec3::splat(1.0),
+            ..default()
+        },
+    ));
+}
+
+fn show_bounds(mut gizmos: Gizmos) {
+    // Display focus bound shape
+    gizmos.cuboid(Transform::from_translation(Vec3::splat(1.0)), WHITE);
+}


### PR DESCRIPTION
A hack I made to add bounds to the camera when panning. If this is something you'd consider implementing please let me know, support for different shaped boundaries would be nice to have, this is just a starting point