### PR TITLE
Upgrade bevy_egui to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_window",
 ] }
-bevy_egui = { version = "0.32", optional = true, default-features = false }
+bevy_egui = { version = "0.33", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = { version = "0.15" }
 float-cmp = "0.10.0"
-bevy_egui = { version = "0.32", default-features = false, features = [
+bevy_egui = { version = "0.33", default-features = false, features = [
     "render",
     "default_fonts",
 ] }


### PR DESCRIPTION
This PR upgrades the `bevy_egui` dependency to the latest released version of `bevy_egui` (`0.33.0`)
