### PR TITLE
Axis swapping first version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,2 @@
 /target
 /Cargo.lock
-# Devenv
-.devenv*
-devenv.local.nix
-
-# direnv
-.direnv
-
-# pre-commit
-.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /target
 /Cargo.lock
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/examples/swapped_axis.rs
+++ b/examples/swapped_axis.rs
@@ -1,0 +1,50 @@
+//! Demonstrates the simplest usage
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Rotation to mimick a rotated world.
+    let rotate = Transform::from_rotation(Quat::from_rotation_x(90.0f32.to_radians()));
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+        rotate,
+    ));
+    // Cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        rotate * Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        rotate * Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    // Swaps the axis of the camera to use Z as up insteaed of Y as up which is the default.
+    let swapped_axis = [Vec3::X, Vec3::Z, Vec3::Y];
+    let camera = PanOrbitCamera {
+        axis: swapped_axis,
+        pitch: Some(-45f32.to_radians()),
+        ..default()
+    };
+    commands.spawn((Transform::from_xyz(0.0, 1.5, 5.0), camera));
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -74,13 +74,13 @@ pub fn orbit_pressed(
 ) -> bool {
     let is_pressed = pan_orbit
         .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
+        .is_none_or(|modifier| key_input.pressed(modifier))
         && mouse_input.pressed(pan_orbit.button_orbit);
 
     is_pressed
         && pan_orbit
             .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
+            .is_none_or(|modifier| !key_input.pressed(modifier))
 }
 
 pub fn orbit_just_pressed(
@@ -90,13 +90,13 @@ pub fn orbit_just_pressed(
 ) -> bool {
     let just_pressed = pan_orbit
         .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
+        .is_none_or(|modifier| key_input.pressed(modifier))
         && (mouse_input.just_pressed(pan_orbit.button_orbit));
 
     just_pressed
         && pan_orbit
             .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
+            .is_none_or(|modifier| !key_input.pressed(modifier))
 }
 
 pub fn orbit_just_released(
@@ -106,13 +106,13 @@ pub fn orbit_just_released(
 ) -> bool {
     let just_released = pan_orbit
         .modifier_orbit
-        .map_or(true, |modifier| key_input.pressed(modifier))
+        .is_none_or(|modifier| key_input.pressed(modifier))
         && (mouse_input.just_released(pan_orbit.button_orbit));
 
     just_released
         && pan_orbit
             .modifier_pan
-            .map_or(true, |modifier| !key_input.pressed(modifier))
+            .is_none_or(|modifier| !key_input.pressed(modifier))
 }
 
 pub fn pan_pressed(
@@ -122,13 +122,13 @@ pub fn pan_pressed(
 ) -> bool {
     let is_pressed = pan_orbit
         .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
+        .is_none_or(|modifier| key_input.pressed(modifier))
         && mouse_input.pressed(pan_orbit.button_pan);
 
     is_pressed
         && pan_orbit
             .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
+            .is_none_or(|modifier| !key_input.pressed(modifier))
 }
 
 pub fn pan_just_pressed(
@@ -138,11 +138,11 @@ pub fn pan_just_pressed(
 ) -> bool {
     let just_pressed = pan_orbit
         .modifier_pan
-        .map_or(true, |modifier| key_input.pressed(modifier))
+        .is_none_or(|modifier| key_input.pressed(modifier))
         && (mouse_input.just_pressed(pan_orbit.button_pan));
 
     just_pressed
         && pan_orbit
             .modifier_orbit
-            .map_or(true, |modifier| !key_input.pressed(modifier))
+            .is_none_or(|modifier| !key_input.pressed(modifier))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,12 +2,18 @@ use bevy::prelude::*;
 
 const EPSILON: f32 = 0.001;
 
-pub fn calculate_from_translation_and_focus(translation: Vec3, focus: Vec3) -> (f32, f32, f32) {
+pub fn calculate_from_translation_and_focus(
+    translation: Vec3,
+    focus: Vec3,
+    axis: [Vec3; 3],
+) -> (f32, f32, f32) {
+    let axis = Mat3::from_cols(axis[0], axis[1], axis[2]);
     let comp_vec = translation - focus;
     let mut radius = comp_vec.length();
     if radius == 0.0 {
         radius = 0.05; // Radius 0 causes problems
     }
+    let comp_vec = axis * comp_vec;
     let yaw = comp_vec.x.atan2(comp_vec.z);
     let pitch = (comp_vec.y / radius).asin();
     (yaw, pitch, radius)
@@ -21,6 +27,7 @@ pub fn update_orbit_transform(
     focus: Vec3,
     transform: &mut Transform,
     projection: &mut Projection,
+    axis: [Vec3; 3],
 ) {
     let mut new_transform = Transform::IDENTITY;
     if let Projection::Orthographic(ref mut p) = *projection {
@@ -28,7 +35,9 @@ pub fn update_orbit_transform(
         // (near + far) / 2.0 ensures that objects near `focus` are not clipped
         radius = (p.near + p.far) / 2.0;
     }
-    new_transform.rotation *= Quat::from_rotation_y(yaw) * Quat::from_rotation_x(-pitch);
+    let yaw_rot = Quat::from_axis_angle(axis[1], yaw);
+    let pitch_rot = Quat::from_axis_angle(axis[0], -pitch);
+    new_transform.rotation *= yaw_rot * pitch_rot;
     new_transform.translation += focus + new_transform.rotation * Vec3::new(0.0, 0.0, radius);
     *transform = new_transform;
 }
@@ -60,12 +69,25 @@ mod calculate_from_translation_and_focus_tests {
     use super::*;
     use float_cmp::approx_eq;
     use std::f32::consts::PI;
+    const AXIS: [Vec3; 3] = [Vec3::X, Vec3::Y, Vec3::Z];
+    const AXIS_Z_UP: [Vec3; 3] = [Vec3::X, Vec3::Z, Vec3::Y];
 
     #[test]
     fn zero() {
         let translation = Vec3::new(0.0, 0.0, 0.0);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
+        assert_eq!(yaw, 0.0);
+        assert_eq!(pitch, 0.0);
+        assert_eq!(radius, 0.05);
+    }
+
+    #[test]
+    fn zero_z_up_axis() {
+        let translation = Vec3::new(0.0, 0.0, 0.0);
+        let focus = Vec3::ZERO;
+        let (yaw, pitch, radius) =
+            calculate_from_translation_and_focus(translation, focus, AXIS_Z_UP);
         assert_eq!(yaw, 0.0);
         assert_eq!(pitch, 0.0);
         assert_eq!(radius, 0.05);
@@ -75,7 +97,18 @@ mod calculate_from_translation_and_focus_tests {
     fn in_front() {
         let translation = Vec3::new(0.0, 0.0, 5.0);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
+        assert_eq!(yaw, 0.0);
+        assert_eq!(pitch, 0.0);
+        assert_eq!(radius, 5.0);
+    }
+
+    #[test]
+    fn in_front_z_up_axis() {
+        let translation = Vec3::new(0.0, 5.0, 0.0);
+        let axis = [Vec3::X, Vec3::Z, Vec3::Y];
+        let focus = Vec3::ZERO;
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, axis);
         assert_eq!(yaw, 0.0);
         assert_eq!(pitch, 0.0);
         assert_eq!(radius, 5.0);
@@ -85,7 +118,7 @@ mod calculate_from_translation_and_focus_tests {
     fn to_the_side() {
         let translation = Vec3::new(5.0, 0.0, 0.0);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
         assert!(approx_eq!(f32, yaw, PI / 2.0));
         assert_eq!(pitch, 0.0);
         assert_eq!(radius, 5.0);
@@ -95,7 +128,18 @@ mod calculate_from_translation_and_focus_tests {
     fn above() {
         let translation = Vec3::new(0.0, 5.0, 0.0);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
+        assert_eq!(yaw, 0.0);
+        assert!(approx_eq!(f32, pitch, PI / 2.0));
+        assert_eq!(radius, 5.0);
+    }
+
+    #[test]
+    fn above_z_as_up_axis() {
+        let translation = Vec3::new(0.0, 0.0, 5.0);
+        let focus = Vec3::ZERO;
+        let (yaw, pitch, radius) =
+            calculate_from_translation_and_focus(translation, focus, AXIS_Z_UP);
         assert_eq!(yaw, 0.0);
         assert!(approx_eq!(f32, pitch, PI / 2.0));
         assert_eq!(radius, 5.0);
@@ -105,7 +149,7 @@ mod calculate_from_translation_and_focus_tests {
     fn arbitrary() {
         let translation = Vec3::new(0.92563736, 3.864204, -1.0105048);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
         assert!(approx_eq!(f32, yaw, 2.4));
         assert!(approx_eq!(f32, pitch, 1.23));
         assert_eq!(radius, 4.1);
@@ -115,7 +159,7 @@ mod calculate_from_translation_and_focus_tests {
     fn negative_x() {
         let translation = Vec3::new(-5.0, 5.0, 9.0);
         let focus = Vec3::ZERO;
-        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus);
+        let (yaw, pitch, radius) = calculate_from_translation_and_focus(translation, focus, AXIS);
         assert!(approx_eq!(f32, yaw, -0.5070985));
         assert!(approx_eq!(f32, pitch, 0.45209613));
         assert!(approx_eq!(f32, radius, 11.445523));


### PR DESCRIPTION
Hi,

this is a first version the ability to swap axis. The reason is that Bevy treats +Y as default up axis. However this does not align with some standard frames that are used e.g. in astrodynamics. There the default up direction is usually +Z. Also see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Tutorials/pdf/individual_docs/17_frames_and_coordinate_systems.pdf .
In this case all the objects would have to be rotated which is very inconvenient. A common use case it to have the center at the earth and use the J2000 frame. For having the earth at the center and just orbiting around bevy_panorbit_camera is perfect if this change is considered.

Please let me know what you think. I already tested it manually in my project and it works nicely. Also I added a few small tests following your testing approach.

BR,
Guillermo