### PR TITLE
Disable orbiting direction inversion if camera is below default presentation plane.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub struct PanOrbitCamera {
     /// Whether to revert the orbiting directon if the camera is upside down.
     /// The camera is upside down if it is below the default presentation plane.
     /// The presentation plane is spanned by the first and last axis for the `axis` setting.
-    /// Default value is false.
+    /// Default value is true.
     pub reverse_orbiting_direction_if_uspside_down: bool,
     /// If `false`, disable control of the camera. Defaults to `true`.
     pub enabled: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,17 +233,17 @@ pub struct PanOrbitCamera {
     pub reversed_zoom: bool,
     /// Whether the camera is currently upside down. Updated automatically.
     /// This is used to determine which way to orbit, because it's more intuitive to reverse the
-    /// orbit direction when upside down.
+    /// orbit direction when upside down. Also see `reverse_orbiting_direction_if_uspside_down`.
     /// Should not be set manually unless you know what you're doing.
     /// Defaults to `false` (but will be updated immediately).
     pub is_upside_down: bool,
     /// Whether to allow the camera below the default presentation plane. The presentation plane is
-    /// spanned by the first two axis for the `axis` setting.
+    /// spanned by the first and last axis of the axis setting.
     /// Defaults to `false`.
     pub allow_upside_down: bool,
     /// Whether to revert the orbiting directon if the camera is upside down.
     /// The camera is upside down if it is below the default presentation plane.
-    /// The presentation plane is spanned by the first two axis for the `axis` setting.
+    /// The presentation plane is spanned by the first and last axis for the `axis` setting.
     /// Default value is false.
     pub reverse_orbiting_direction_if_uspside_down: bool,
     /// If `false`, disable control of the camera. Defaults to `true`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,9 +237,15 @@ pub struct PanOrbitCamera {
     /// Should not be set manually unless you know what you're doing.
     /// Defaults to `false` (but will be updated immediately).
     pub is_upside_down: bool,
-    /// Whether to allow the camera to go upside down.
+    /// Whether to allow the camera below the default presentation plane. The presentation plane is
+    /// spanned by the first two axis for the `axis` setting.
     /// Defaults to `false`.
     pub allow_upside_down: bool,
+    /// Whether to revert the orbiting directon if the camera is upside down.
+    /// The camera is upside down if it is below the default presentation plane.
+    /// The presentation plane is spanned by the first two axis for the `axis` setting.
+    /// Default value is false.
+    pub reverse_orbiting_direction_if_uspside_down: bool,
     /// If `false`, disable control of the camera. Defaults to `true`.
     pub enabled: bool,
     /// Whether `PanOrbitCamera` has been initialized with the initial config.
@@ -265,6 +271,7 @@ impl Default for PanOrbitCamera {
             radius: None,
             is_upside_down: false,
             allow_upside_down: false,
+            reverse_orbiting_direction_if_uspside_down: true,
             orbit_sensitivity: 1.0,
             orbit_smoothness: 0.1,
             pan_sensitivity: 1.0,
@@ -590,7 +597,9 @@ fn pan_orbit_camera(
             if let Some(win_size) = active_cam.window_size {
                 let delta_x = {
                     let delta = orbit.x / win_size.x * PI * 2.0;
-                    if pan_orbit.is_upside_down {
+                    if pan_orbit.reverse_orbiting_direction_if_uspside_down
+                        && pan_orbit.is_upside_down
+                    {
                         -delta
                     } else {
                         delta


### PR DESCRIPTION
**Motivation:**

In my use case it is more intuitive to keep the default rotation and not invert it if the camera is below the default orbital plane as you would never usually really want to "invert the camera", but just "see it from below". See also the gif.

**Change:**

Introduced an attribute to control whether the orbiting direction is inverted if the camera is below the default presentation plane.

![rotation](https://github.com/user-attachments/assets/8834526a-5d8f-4046-a601-1f4acfbdd0e4)

What do you think?