### PR TITLE
update bevy_egui to 0.35, bump bevy to 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ readme = "README.md"
 bevy_egui = ["dep:bevy_egui"]
 
 [dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.16.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_window",
 ] }
-bevy_egui = { version = "0.34", optional = true, default-features = false }
+bevy_egui = { version = "0.35", optional = true, default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.16" }
+bevy = { version = "0.16.1" }
 float-cmp = "0.10.0"
-bevy_egui = { version = "0.34", default-features = false, features = [
+bevy_egui = { version = "0.35", default-features = false, features = [
     "render",
     "default_fonts",
 ] }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -2,18 +2,16 @@
 //! egui windows
 
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: false,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, ui_example_system);
+        .add_systems(EguiPrimaryContextPass, ui_example_system);
 
     app.run();
 }
@@ -49,20 +47,21 @@ fn setup(
     ));
 }
 
-fn ui_example_system(mut contexts: EguiContexts) {
+fn ui_example_system(mut contexts: EguiContexts) -> Result {
     egui::SidePanel::left("left_panel")
         .resizable(true)
-        .show(contexts.ctx_mut(), |ui| {
+        .show(contexts.ctx_mut()?, |ui| {
             ui.label("Left resizeable panel");
         });
 
-    egui::Window::new("Movable Window").show(contexts.ctx_mut(), |ui| {
+    egui::Window::new("Movable Window").show(contexts.ctx_mut()?, |ui| {
         ui.label("Hello world");
     });
 
     egui::Window::new("Immovable Window")
         .movable(false)
-        .show(contexts.ctx_mut(), |ui| {
+        .show(contexts.ctx_mut()?, |ui| {
             ui.label("Hello world");
         });
+    Ok(())
 }


### PR DESCRIPTION
Hello,

I've updated bevy_egui to the latest released version. The changes required include updating how we check egui contexts, as upstream modifications have decoupled them from Window entities and instead attached them to Camera entities. Additionally, the examples now reflect the current "correct" way to interact with egui, addressing issue #113 by handling multipass egui through custom marked schedules. This is demonstrated in the multi-window example. Also bumped bevy patch version.