### PR TITLE
bump bevy_egui to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ bevy = { version = "0.17", default-features = false, features = [
     "bevy_camera",
     "bevy_window",
 ] }
-bevy_egui = { version = "0.37", optional = true, default-features = false }
+bevy_egui = { version = "0.38", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = { version = "0.17" }
 float-cmp = "0.10.0"
-bevy_egui = { version = "0.37", default-features = false, features = [
+bevy_egui = { version = "0.38", default-features = false, features = [
     "render",
     "default_fonts",
 ] }


### PR DESCRIPTION
Bumping the dependency version compiled without warnings or errors.


<details>
  <summary>cargo test --features bevy_egui:</summary>

  ```
      Finished `test` profile [unoptimized + debuginfo] target(s) in 9.88s
       Running unittests src\lib.rs (target\debug\deps\bevy_panorbit_camera-567e9e2dd519a0ae.exe)
  
  running 18 tests
  test util::approx_equal_tests::same_value_is_approx_equal ... ok
  test util::calculate_from_translation_and_focus_tests::in_front_z_up_axis ... ok
  test util::lerp_and_snap_f32_tests::lerps_when_output_outside_snap_threshold ... ok
  test util::lerp_and_snap_vec3_tests::does_not_snap_if_smoothness_is_one ... ok
  test util::calculate_from_translation_and_focus_tests::above_z_as_up_axis ... ok
  test util::calculate_from_translation_and_focus_tests::zero_z_up_axis ... ok
  test util::calculate_from_translation_and_focus_tests::zero ... ok
  test util::approx_equal_tests::value_within_threshold_is_approx_equal ... ok
  test util::lerp_and_snap_f32_tests::does_not_snap_if_smoothness_is_one ... ok
  test util::calculate_from_translation_and_focus_tests::above ... ok
  test util::approx_equal_tests::value_outside_threshold_is_not_approx_equal ... ok
  test util::calculate_from_translation_and_focus_tests::negative_x ... ok
  test util::calculate_from_translation_and_focus_tests::arbitrary ... ok
  test util::lerp_and_snap_f32_tests::snaps_to_target_when_inside_threshold ... ok
  test util::lerp_and_snap_vec3_tests::lerps_when_output_outside_snap_threshold ... ok
  test util::calculate_from_translation_and_focus_tests::in_front ... ok
  test util::calculate_from_translation_and_focus_tests::to_the_side ... ok
  test util::lerp_and_snap_vec3_tests::snaps_to_target_when_inside_threshold ... ok
  
  test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
  
     Doc-tests bevy_panorbit_camera
  
  running 4 tests
  test src\lib.rs - (line 45) ... ignored
  test src\lib.rs - (line 51) ... ignored
  test src\lib.rs - PanOrbitCameraPlugin (line 31) - compile ... ok
  test src\lib.rs - PanOrbitCamera (line 86) - compile ... ok
  
  test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 5.05s
  ```
</details>

The `egui` example compiles and appears to run properly.