### PR TITLE
Add `reversed_button_zoom`

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -75,6 +75,8 @@ fn setup(
             button_zoom: Some(MouseButton::Right),
             // Optionally configure button zoom to use left-right mouse movement
             // button_zoom_axis: ButtonZoomAxis::X,
+            // Optionally reverse the button-based zoom independently to `reversed_zoom`
+            // button_zoom_reverse: true,
             // Reverse the zoom direction
             reversed_zoom: true,
             // Use alternate touch controls

--- a/src/input.rs
+++ b/src/input.rs
@@ -54,11 +54,14 @@ pub fn mouse_key_tracker(
 
     // If zoom button set, apply zoom based on mouse movement
     let mouse_zoom = if button_zoom_pressed(pan_orbit, &mouse_input) {
-        let delta = match pan_orbit.button_zoom_axis {
+        let mut delta = match pan_orbit.button_zoom_axis {
             ButtonZoomAxis::X => mouse_delta.x,
             ButtonZoomAxis::Y => -mouse_delta.y,
             ButtonZoomAxis::XY => mouse_delta.x + -mouse_delta.y,
         };
+        if pan_orbit.reversed_button_zoom {
+            delta *= -1.0;
+        }
         delta * 0.03
     } else {
         0.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,9 +249,13 @@ pub struct PanOrbitCamera {
     /// operations when using a trackpad with the `BlenderLike` behavior mode.
     /// Defaults to `1.0`.
     pub trackpad_sensitivity: f32,
-    /// Whether to reverse the zoom direction.
+    /// Whether to reverse the zoom direction. This applies to the button-based zoom `button_zoom`
+    /// as well. If you want button zoom to remain the same, set `button_zoom_reverse` to `true`.
     /// Defaults to `false`.
     pub reversed_zoom: bool,
+    /// Whether the zoom direction when using `button_zoom` is reversed.
+    /// Defaults to `false`.
+    pub reversed_button_zoom: bool,
     /// Whether the camera is currently upside down. Updated automatically.
     /// This is used to determine which way to orbit, because it's more intuitive to reverse the
     /// orbit direction when upside down.
@@ -301,6 +305,7 @@ impl Default for PanOrbitCamera {
             button_pan: MouseButton::Right,
             button_zoom: None,
             button_zoom_axis: ButtonZoomAxis::Y,
+            reversed_button_zoom: false,
             modifier_orbit: None,
             modifier_pan: None,
             touch_enabled: true,


### PR DESCRIPTION
Adds additional field on top of https://github.com/Plonq/bevy_panorbit_camera/pull/129 to reverse the direction of the button zoom only, so it can be independent of the direction of the scroll wheel zoom.

Relevant Issue: #128 