### PR TITLE
Fix bevy 0.18 version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ all the possible configuration options.
 
 | bevy | bevy_panorbit_camera |
 |------|----------------------|
-| 0.18 | 0.24                 |
+| 0.18 | 0.34                 |
 | 0.17 | 0.29-0.33            |
 | 0.16 | 0.26-0.28            |
 | 0.15 | 0.21-0.25            |


### PR DESCRIPTION
The README mentioned bevy_panorbit_camera 0.24 is needed for Bevy 0.18, but it should be 0.34 from what I see in https://github.com/Plonq/bevy_panorbit_camera/tags