### PR TITLE
feat: add optional extras feature for zoom-to-fit, animations, and debug visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Add optional `extras` feature: zoom-to-fit, queued camera animations, event-driven camera control
 - Add optional `extras_debug` feature: debug visualization of fit targets with gizmos and screen-space labels
-- Add 4 examples: `extras_zoom_to_fit`, `extras_animate_to_fit`, `extras_play_animation`, `extras_look_at`
+- Add `extras` example: full showcase with mesh picking, multi-window, animations, and debug visualization
+- Add 4 focused examples: `extras_zoom_to_fit`, `extras_animate_to_fit`, `extras_play_animation`, `extras_look_at`
 
 ## 0.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+- Add optional `extras` feature: zoom-to-fit, queued camera animations, event-driven camera control
+- Add optional `extras_debug` feature: debug visualization of fit targets with gizmos and screen-space labels
+- Add 4 examples: `extras_zoom_to_fit`, `extras_animate_to_fit`, `extras_play_animation`, `extras_look_at`
+
 ## 0.34.0
 
 - Update to Bevy 0.18

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ readme = "README.md"
 
 [features]
 bevy_egui = ["dep:bevy_egui"]
+extras = ["bevy/bevy_asset", "bevy/bevy_log", "bevy/bevy_mesh"]
+extras_debug = [
+    "extras",
+    "bevy/bevy_gizmos",
+    "bevy/bevy_pbr",
+    "bevy/bevy_picking",
+    "bevy/bevy_state",
+    "bevy/bevy_text",
+    "bevy/bevy_ui",
+]
 
 [dependencies]
 bevy = { version = "0.18", default-features = false, features = [
@@ -37,3 +47,19 @@ required-features = ["bevy_egui"]
 [[example]]
 name = "egui_multiple_windows"
 required-features = ["bevy_egui"]
+
+[[example]]
+name = "extras_zoom_to_fit"
+required-features = ["extras"]
+
+[[example]]
+name = "extras_animate_to_fit"
+required-features = ["extras"]
+
+[[example]]
+name = "extras_play_animation"
+required-features = ["extras"]
+
+[[example]]
+name = "extras_look_at"
+required-features = ["extras"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ bevy_egui = { version = "0.39", default-features = false, features = [
     "render",
     "default_fonts",
 ] }
-bevy_brp_extras = "0.18.7"
-bevy_window_manager = "0.18.3"
+bevy_brp_extras = "0.19.0"
+bevy_window_manager = "0.19.0"
 bevy_panorbit_camera = { path = ".", features = ["extras_debug"] }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ bevy_egui = { version = "0.39", default-features = false, features = [
     "render",
     "default_fonts",
 ] }
+bevy_brp_extras = "0.18.7"
+bevy_window_manager = "0.18.3"
+bevy_panorbit_camera = { path = ".", features = ["extras_debug"] }
 
 [[example]]
 name = "egui"
@@ -49,8 +52,12 @@ name = "egui_multiple_windows"
 required-features = ["bevy_egui"]
 
 [[example]]
+name = "extras"
+required-features = ["extras_debug"]
+
+[[example]]
 name = "extras_zoom_to_fit"
-required-features = ["extras"]
+required-features = ["extras_debug"]
 
 [[example]]
 name = "extras_animate_to_fit"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use it to quickly prototype, experiment, for model viewers, and more!
 - Works with multiple viewports and/or windows
 - Easy to control manually, e.g. for keyboard control or animation
 - Can control cameras that render to a texture
+- Zoom-to-fit, camera animations, and debug visualization (optional `extras` feature)
 
 ## Controls
 
@@ -63,6 +64,49 @@ all the possible configuration options.
 
 - `bevy_egui` (optional): Makes `PanOrbitCamera` ignore any input that `egui` uses, thus preventing moving the camera
   when interacting with egui windows
+- `extras` (optional): Zoom-to-fit, queued camera animations, and event-driven camera control
+- `extras_debug` (optional, implies `extras`): Debug visualization of fit targets with gizmos and screen-space labels
+
+## Extras
+
+Enable the `extras` feature for zoom-to-fit, queued camera animations, and event-driven camera control:
+
+```toml
+bevy_panorbit_camera = { version = "0.35", features = ["extras"] }
+```
+
+Trigger a zoom-to-fit:
+
+```rust ignore
+commands.entity(camera).trigger(ZoomToFit {
+    target,
+    margin: 0.15,
+    ..default()
+});
+```
+
+Queue camera animations:
+
+```rust ignore
+commands.entity(camera).trigger(PlayAnimation {
+    moves: vec![CameraMove::ToOrbit { .. }],
+    ..default()
+});
+```
+
+Look at a target:
+
+```rust ignore
+commands.entity(camera).trigger(LookAt { target, duration, easing });
+```
+
+For debug visualization of fit targets, enable `extras_debug`:
+
+```toml
+bevy_panorbit_camera = { version = "0.35", features = ["extras_debug"] }
+```
+
+See the `extras_*` examples for more.
 
 ## Version Compatibility
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ all the possible configuration options.
 - `bevy_egui` (optional): Makes `PanOrbitCamera` ignore any input that `egui` uses, thus preventing moving the camera
   when interacting with egui windows
 - `extras` (optional): Zoom-to-fit, queued camera animations, and event-driven camera control
-- `extras_debug` (optional, implies `extras`): Debug visualization of fit targets with gizmos and screen-space labels
+- `extras_debug` (optional, enabling this implicitly enables `extras`): Debug visualization of fit targets with gizmos and screen-space labels
 
 ## Extras
 

--- a/examples/extras.rs
+++ b/examples/extras.rs
@@ -779,6 +779,9 @@ fn on_mesh_clicked(
     active_easing: Res<ActiveEasing>,
     time: Res<Time<Virtual>>,
 ) {
+    if click.button != PointerButton::Primary {
+        return;
+    }
     if time.is_paused() {
         return;
     }
@@ -805,6 +808,9 @@ fn on_ground_clicked(
     active_easing: Res<ActiveEasing>,
     time: Res<Time<Virtual>>,
 ) {
+    if click.button != PointerButton::Primary {
+        return;
+    }
     if time.is_paused() {
         return;
     }
@@ -829,6 +835,9 @@ fn on_below_clicked(
     active_easing: Res<ActiveEasing>,
     time: Res<Time<Virtual>>,
 ) {
+    if click.button != PointerButton::Primary {
+        return;
+    }
     if time.is_paused() {
         return;
     }

--- a/examples/extras.rs
+++ b/examples/extras.rs
@@ -1,0 +1,1580 @@
+//! Demonstrates clicking on meshes to zoom-to-fit using `bevy_panorbit_camera_ext`.
+//!
+//! - Click a mesh to select it and zoom the camera to frame it
+//! - Click the ground to deselect and zoom out to the full scene
+//! - Drag a mesh to rotate it
+//! - Selected meshes show a gizmo outline
+//! - Press 'D' to toggle debug visualization of zoom-to-fit bounds
+
+use std::f32::consts::PI;
+use std::time::Duration;
+
+use bevy::camera::visibility::RenderLayers;
+use bevy::camera::RenderTarget;
+use bevy::camera::ScalingMode;
+use bevy::color::palettes::css::DEEP_SKY_BLUE;
+use bevy::color::palettes::css::ORANGE;
+use bevy::math::curve::easing::EaseFunction;
+use bevy::prelude::*;
+use bevy::time::Virtual;
+use bevy::ui::UiTargetCamera;
+use bevy::window::WindowRef;
+use bevy_brp_extras::BrpExtrasPlugin;
+use bevy_panorbit_camera::AnimateToFit;
+use bevy_panorbit_camera::AnimationBegin;
+use bevy_panorbit_camera::AnimationCancelled;
+use bevy_panorbit_camera::AnimationConflictPolicy;
+use bevy_panorbit_camera::AnimationEnd;
+use bevy_panorbit_camera::AnimationRejected;
+use bevy_panorbit_camera::AnimationSource;
+use bevy_panorbit_camera::CameraInputInterruptBehavior;
+use bevy_panorbit_camera::CameraMove;
+use bevy_panorbit_camera::CameraMoveBegin;
+use bevy_panorbit_camera::CameraMoveEnd;
+use bevy_panorbit_camera::FitVisualization;
+use bevy_panorbit_camera::LookAt;
+use bevy_panorbit_camera::LookAtAndZoomToFit;
+use bevy_panorbit_camera::PanOrbitCamera;
+use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::PlayAnimation;
+use bevy_panorbit_camera::TrackpadBehavior;
+use bevy_panorbit_camera::ZoomBegin;
+use bevy_panorbit_camera::ZoomCancelled;
+use bevy_panorbit_camera::ZoomEnd;
+use bevy_panorbit_camera::ZoomToFit;
+use bevy_window_manager::ManagedWindow;
+use bevy_window_manager::WindowManagerPlugin;
+
+// durations
+const ANIMATE_FIT_DURATION_MS: u64 = 1200;
+const ORBIT_MOVE_DURATION_MS: u64 = 800;
+const LOOK_AT_DURATION_MS: u64 = 800;
+const ZOOM_DURATION_MS: u64 = 1000;
+
+// camera home
+const CAMERA_START_PITCH: f32 = 0.4;
+const CAMERA_START_YAW: f32 = -0.2;
+
+// sensitivity
+const DRAG_SENSITIVITY: f32 = 0.02;
+
+// event log
+const EVENT_LOG_COLOR: Color = Color::srgba(0.0, 1.0, 0.0, 0.9);
+const EVENT_LOG_COLOR_RED: Color = Color::srgba(1.0, 0.3, 0.3, 0.9);
+const EVENT_LOG_FONT_SIZE: f32 = 14.0;
+const EVENT_LOG_SCROLL_SPEED: f32 = 120.0;
+const EVENT_LOG_SEPARATOR: &str = "- - - - - - - - - - - -";
+const EVENT_LOG_WIDTH: f32 = 300.0;
+const UI_FONT_SIZE: f32 = 13.0;
+
+// mesh settings
+const GIZMO_DEPTH_BIAS: f32 = -0.005;
+const GIZMO_LINE_WIDTH: f32 = 2.0;
+const GIZMO_SCALE: f32 = 1.001;
+const MESH_CENTER_Y: f32 = 1.0;
+const SELECTION_GIZMO_LAYER: usize = 1;
+const ZOOM_MARGIN_MESH: f32 = 0.15;
+const ZOOM_MARGIN_SCENE: f32 = 0.08;
+
+// window label
+const WINDOW_LABEL_DURATION_SECS: f32 = 2.0;
+
+// the easings!
+const ALL_EASINGS: &[EaseFunction] = &[
+    EaseFunction::Linear,
+    EaseFunction::QuadraticIn,
+    EaseFunction::QuadraticOut,
+    EaseFunction::QuadraticInOut,
+    EaseFunction::CubicIn,
+    EaseFunction::CubicOut,
+    EaseFunction::CubicInOut,
+    EaseFunction::QuarticIn,
+    EaseFunction::QuarticOut,
+    EaseFunction::QuarticInOut,
+    EaseFunction::QuinticIn,
+    EaseFunction::QuinticOut,
+    EaseFunction::QuinticInOut,
+    EaseFunction::SmoothStepIn,
+    EaseFunction::SmoothStepOut,
+    EaseFunction::SmoothStep,
+    EaseFunction::SmootherStepIn,
+    EaseFunction::SmootherStepOut,
+    EaseFunction::SmootherStep,
+    EaseFunction::SineIn,
+    EaseFunction::SineOut,
+    EaseFunction::SineInOut,
+    EaseFunction::CircularIn,
+    EaseFunction::CircularOut,
+    EaseFunction::CircularInOut,
+    EaseFunction::ExponentialIn,
+    EaseFunction::ExponentialOut,
+    EaseFunction::ExponentialInOut,
+    EaseFunction::ElasticIn,
+    EaseFunction::ElasticOut,
+    EaseFunction::ElasticInOut,
+    EaseFunction::BackIn,
+    EaseFunction::BackOut,
+    EaseFunction::BackInOut,
+    EaseFunction::BounceIn,
+    EaseFunction::BounceOut,
+    EaseFunction::BounceInOut,
+];
+
+// ============================================================================
+// Types
+// ============================================================================
+
+#[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
+enum AppState {
+    #[default]
+    Loading,
+    Running,
+}
+
+#[derive(Component)]
+struct Selected;
+
+#[derive(Default, Reflect, GizmoConfigGroup)]
+struct SelectionGizmo;
+
+#[derive(Component)]
+enum MeshShape {
+    Cuboid(Vec3),
+    Sphere(f32),
+    Torus {
+        minor_radius: f32,
+        major_radius: f32,
+    },
+}
+
+#[derive(Resource)]
+struct SceneEntities {
+    camera: Entity,
+    scene_bounds: Entity,
+}
+
+#[derive(Resource)]
+struct ActiveEasing(EaseFunction);
+
+impl Default for ActiveEasing {
+    fn default() -> Self {
+        Self(EaseFunction::CubicOut)
+    }
+}
+
+#[derive(Component)]
+struct EventLogNode;
+
+#[derive(Component)]
+struct CameraInputInterruptBehaviorLabel;
+
+#[derive(Component)]
+struct AnimationConflictPolicyLabel;
+
+#[derive(Component)]
+struct PausedOverlay;
+
+#[derive(Component)]
+struct EventLogHint;
+
+#[derive(Component)]
+struct EventLogToggleHint;
+
+#[derive(Resource)]
+struct SecondWindowEntities {
+    window: Entity,
+    camera: Entity,
+}
+
+#[derive(Component)]
+struct SecondWindowCamera;
+
+#[derive(Component)]
+struct WindowLabel(Timer);
+
+/// Tracks the mesh entity currently under the cursor for `LookAt` / `LookAtAndZoomToFit`.
+#[derive(Resource, Default)]
+struct HoveredEntity(Option<Entity>);
+
+/// Marker resource: when present, the next `AnimationEnd` enables the event log.
+#[derive(Resource)]
+struct EnableLogOnAnimationEnd;
+
+struct PendingLogEntry {
+    text: String,
+    color: Color,
+}
+
+#[derive(Resource, Default)]
+struct EventLog {
+    enabled: bool,
+    pending: Vec<PendingLogEntry>,
+}
+
+// ============================================================================
+// App entry point
+// ============================================================================
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "extras - window 1".into(),
+                    ..default()
+                }),
+                ..default()
+            }),
+            PanOrbitCameraPlugin,
+            MeshPickingPlugin,
+            BrpExtrasPlugin::default(),
+            WindowManagerPlugin,
+        ))
+        .init_gizmo_group::<SelectionGizmo>()
+        .init_state::<AppState>()
+        .init_resource::<ActiveEasing>()
+        .init_resource::<EventLog>()
+        .init_resource::<HoveredEntity>()
+        .add_systems(Startup, (setup, init_selection_gizmo))
+        .add_systems(
+            Update,
+            initial_fit_to_scene.run_if(in_state(AppState::Loading)),
+        )
+        .add_systems(
+            Update,
+            (
+                cleanup_second_window,
+                log_window_focus,
+                despawn_window_labels,
+                toggle_pause,
+                toggle_event_log,
+                draw_selection_gizmo,
+                draw_hover_gizmo,
+                sync_selection_gizmo_layers,
+                update_event_log_text,
+                scroll_event_log,
+                (
+                    toggle_second_window,
+                    toggle_debug_visualization,
+                    toggle_projection,
+                    randomize_easing,
+                    animate_camera,
+                    animate_fit_to_scene,
+                    toggle_interrupt_behavior,
+                    toggle_animation_conflict_policy,
+                    look_at_hovered,
+                    look_at_and_zoom_to_fit_hovered,
+                )
+                    .run_if(not_paused),
+            ),
+        )
+        .add_observer(enable_log_on_initial_fit)
+        .add_observer(log_animation_begin)
+        .add_observer(log_animation_end)
+        .add_observer(log_animation_cancelled)
+        .add_observer(log_camera_move_start)
+        .add_observer(log_camera_move_end)
+        .add_observer(log_zoom_begin)
+        .add_observer(log_zoom_end)
+        .add_observer(log_zoom_cancelled)
+        .add_observer(log_animation_rejected)
+        .run();
+}
+
+// ============================================================================
+// Scene setup
+// ============================================================================
+
+fn init_selection_gizmo(mut config_store: ResMut<GizmoConfigStore>) {
+    let (config, _) = config_store.config_mut::<SelectionGizmo>();
+    config.depth_bias = GIZMO_DEPTH_BIAS;
+    config.line.width = GIZMO_LINE_WIDTH;
+    config.render_layers = RenderLayers::layer(SELECTION_GIZMO_LAYER);
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground plane (clickable from above — deselects and zooms to scene bounds)
+    let ground = commands
+        .spawn((
+            Mesh3d(meshes.add(Plane3d::default().mesh().size(12.0, 12.0))),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::srgb(0.3, 0.5, 0.3).with_alpha(0.85),
+                alpha_mode: AlphaMode::Blend,
+                double_sided: true,
+                cull_mode: None,
+                ..default()
+            })),
+        ))
+        .observe(on_ground_clicked)
+        .id();
+
+    // Underside plane (clickable from below — deselects and animates back to scene)
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Plane3d::default().mesh().size(12.0, 12.0))),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::srgba(0.0, 0.0, 0.0, 0.0),
+                alpha_mode: AlphaMode::Blend,
+                unlit: true,
+                ..default()
+            })),
+            Transform::from_rotation(Quat::from_rotation_x(PI)),
+        ))
+        .observe(on_below_clicked);
+
+    // Directional light
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 3000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, PI / 4.0, -PI / 4.0)),
+    ));
+
+    // Cuboid
+    let cuboid_size = Vec3::new(1.0, 1.0, 1.0);
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Cuboid::new(cuboid_size.x, cuboid_size.y, cuboid_size.z))),
+            MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+            Transform::from_xyz(-2.5, MESH_CENTER_Y, 0.0),
+            MeshShape::Cuboid(cuboid_size),
+        ))
+        .observe(on_mesh_clicked)
+        .observe(on_mesh_dragged)
+        .observe(on_mesh_hover)
+        .observe(on_mesh_unhover);
+
+    // Sphere
+    let sphere_radius = 0.5;
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Sphere::new(sphere_radius).mesh().uv(128, 64))),
+            MeshMaterial3d(materials.add(Color::srgb(0.9, 0.3, 0.2))),
+            Transform::from_xyz(0.0, MESH_CENTER_Y, 0.0),
+            MeshShape::Sphere(sphere_radius),
+        ))
+        .observe(on_mesh_clicked)
+        .observe(on_mesh_dragged)
+        .observe(on_mesh_hover)
+        .observe(on_mesh_unhover);
+
+    // Torus
+    let torus_minor = 0.25;
+    let torus_major = 0.75;
+    commands
+        .spawn((
+            Mesh3d(
+                meshes.add(
+                    Torus::new(torus_minor, torus_major)
+                        .mesh()
+                        .minor_resolution(64)
+                        .major_resolution(64),
+                ),
+            ),
+            MeshMaterial3d(materials.add(Color::srgb(0.9, 0.5, 0.1))),
+            Transform::from_xyz(2.5, MESH_CENTER_Y, 0.0),
+            MeshShape::Torus {
+                minor_radius: torus_minor,
+                major_radius: torus_major,
+            },
+        ))
+        .observe(on_mesh_clicked)
+        .observe(on_mesh_dragged)
+        .observe(on_mesh_hover)
+        .observe(on_mesh_unhover);
+
+    // Camera (middle-click orbit, shift+middle pan, trackpad support)
+    let camera = commands
+        .spawn(PanOrbitCamera {
+            button_orbit: MouseButton::Middle,
+            button_pan: MouseButton::Middle,
+            modifier_pan: Some(KeyCode::ShiftLeft),
+            trackpad_behavior: TrackpadBehavior::BlenderLike {
+                modifier_pan: Some(KeyCode::ShiftLeft),
+                modifier_zoom: Some(KeyCode::ControlLeft),
+            },
+            trackpad_pinch_to_zoom_enabled: true,
+            yaw: Some(CAMERA_START_YAW),
+            pitch: Some(CAMERA_START_PITCH),
+            ..default()
+        })
+        .id();
+
+    // Instructions
+    commands.spawn((
+        Text::new("Click a mesh to zoom-to-fit\nClick the ground to zoom back out\n\nPress:\n'Esc' pause / unpause\n'P' toggle projection\n'D' debug visualization\n'H' Home w/animate fit to scene\n'A' animate camera\n'F' look at hovered mesh\n'G' look at + zoom-to-fit hovered mesh\n'R' randomize easing\n'E' reset to 'CubicOut' easing\n'I' toggle interrupt behavior\n'Q' cycle conflict policy\n'W' toggle second window"),
+        TextFont {
+            font_size: UI_FONT_SIZE,
+            ..default()
+        },
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        UiTargetCamera(camera),
+    ));
+
+    // Interrupt behavior hint (bottom-left)
+    commands.spawn((
+        Text::new(interrupt_behavior_hint_text(
+            CameraInputInterruptBehavior::Ignore,
+        )),
+        TextFont {
+            font_size: UI_FONT_SIZE,
+            ..default()
+        },
+        TextColor(Color::srgba(0.7, 0.7, 0.7, 0.7)),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        CameraInputInterruptBehaviorLabel,
+        UiTargetCamera(camera),
+    ));
+
+    // Conflict policy hint (bottom-left, above interrupt behavior)
+    commands.spawn((
+        Text::new(conflict_policy_hint_text(AnimationConflictPolicy::LastWins)),
+        TextFont {
+            font_size: UI_FONT_SIZE,
+            ..default()
+        },
+        TextColor(Color::srgba(0.7, 0.7, 0.7, 0.7)),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(32.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        AnimationConflictPolicyLabel,
+        UiTargetCamera(camera),
+    ));
+
+    // Event log scroll container (right edge, scrollable, hidden until enabled)
+    commands.spawn((
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            right: Val::Px(12.0),
+            width: Val::Px(EVENT_LOG_WIDTH),
+            bottom: Val::Px(72.0),
+            flex_direction: FlexDirection::Column,
+            overflow: Overflow::scroll_y(),
+            ..default()
+        },
+        Visibility::Hidden,
+        Pickable::IGNORE,
+        EventLogNode,
+        UiTargetCamera(camera),
+    ));
+
+    // Log toggle hint (bottom-right, always visible once initial animation completes)
+    commands.spawn((
+        Text::new("'L' toggle log off and on"),
+        TextFont {
+            font_size: UI_FONT_SIZE,
+            ..default()
+        },
+        TextColor(Color::srgba(0.7, 0.7, 0.7, 0.7)),
+        TextLayout::new_with_justify(Justify::Left),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(12.0),
+            right: Val::Px(12.0),
+            width: Val::Px(EVENT_LOG_WIDTH),
+            ..default()
+        },
+        Visibility::Hidden,
+        EventLogToggleHint,
+        UiTargetCamera(camera),
+    ));
+
+    // Log scroll/clear hints (bottom-right, hidden until log enabled)
+    commands.spawn((
+        Text::new("Up/Down scroll log\n'C' clear log"),
+        TextFont {
+            font_size: UI_FONT_SIZE,
+            ..default()
+        },
+        TextColor(Color::srgba(0.7, 0.7, 0.7, 0.7)),
+        TextLayout::new_with_justify(Justify::Left),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(28.0),
+            right: Val::Px(12.0),
+            width: Val::Px(EVENT_LOG_WIDTH),
+            ..default()
+        },
+        Visibility::Hidden,
+        EventLogHint,
+        UiTargetCamera(camera),
+    ));
+
+    // Paused overlay (centered, hidden until Esc)
+    commands.spawn((
+        Text::new("PAUSED"),
+        TextFont {
+            font_size: 48.0,
+            ..default()
+        },
+        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.4)),
+        TextLayout::new_with_justify(Justify::Center),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Percent(46.0),
+            width: Val::Percent(100.0),
+            ..default()
+        },
+        Visibility::Hidden,
+        PausedOverlay,
+        UiTargetCamera(camera),
+    ));
+
+    commands.insert_resource(SceneEntities {
+        camera,
+        scene_bounds: ground,
+    });
+}
+
+fn initial_fit_to_scene(
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    mesh_query: Query<&Mesh3d>,
+    meshes: Res<Assets<Mesh>>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    let Ok(mesh3d) = mesh_query.get(scene.scene_bounds) else {
+        return;
+    };
+    if meshes.get(&mesh3d.0).is_none() {
+        return;
+    }
+    commands.insert_resource(EnableLogOnAnimationEnd);
+    commands.trigger(
+        AnimateToFit::new(scene.camera, scene.scene_bounds)
+            .yaw(CAMERA_START_YAW)
+            .pitch(CAMERA_START_PITCH)
+            .margin(ZOOM_MARGIN_SCENE)
+            .easing(EaseFunction::QuadraticInOut),
+    );
+    next_state.set(AppState::Running);
+}
+
+// ============================================================================
+// Second window
+// ============================================================================
+
+fn all_cameras(scene: &SceneEntities, second: Option<&SecondWindowEntities>) -> Vec<Entity> {
+    let mut cameras = vec![scene.camera];
+    if let Some(sw) = second {
+        cameras.push(sw.camera);
+    }
+    cameras
+}
+
+/// Returns the camera entity whose window is currently focused.
+fn focused_camera(
+    scene: &SceneEntities,
+    second: Option<&SecondWindowEntities>,
+    windows: &Query<&Window>,
+) -> Option<Entity> {
+    if let Some(sw) = second {
+        if let Ok(win) = windows.get(sw.window) {
+            if win.focused {
+                return Some(sw.camera);
+            }
+        }
+    }
+    // Primary window is the default fallback
+    Some(scene.camera)
+}
+
+fn toggle_second_window(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    easing: Res<ActiveEasing>,
+    camera_query: Query<&PanOrbitCamera>,
+    mut log: ResMut<EventLog>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyW) {
+        return;
+    }
+
+    if let Some(sw) = second {
+        commands.entity(sw.window).despawn();
+        commands.entity(sw.camera).despawn();
+        commands.remove_resource::<SecondWindowEntities>();
+        log.push("Window 2: closed".into());
+        return;
+    }
+
+    let window = commands
+        .spawn((
+            Window {
+                title: "extras - window 2".into(),
+                ..default()
+            },
+            ManagedWindow {
+                window_name: "window_2".into(),
+            },
+        ))
+        .id();
+
+    // Clone settings from primary camera
+    let Ok(primary) = camera_query.get(scene.camera) else {
+        return;
+    };
+    let mut second_cam = *primary;
+    second_cam.yaw = Some(CAMERA_START_YAW);
+    second_cam.pitch = Some(CAMERA_START_PITCH);
+
+    let camera = commands
+        .spawn((
+            second_cam,
+            RenderTarget::Window(WindowRef::Entity(window)),
+            SecondWindowCamera,
+        ))
+        .id();
+
+    commands.trigger(
+        AnimateToFit::new(camera, scene.scene_bounds)
+            .yaw(CAMERA_START_YAW)
+            .pitch(CAMERA_START_PITCH)
+            .margin(ZOOM_MARGIN_SCENE)
+            .easing(easing.0),
+    );
+
+    // "Window 2" label centered in the second window, auto-despawns after a couple seconds
+    commands.spawn((
+        Text::new("Window 2"),
+        TextFont {
+            font_size: 48.0,
+            ..default()
+        },
+        TextColor(Color::srgba(1.0, 1.0, 1.0, 0.4)),
+        TextLayout::new_with_justify(Justify::Center),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Percent(46.0),
+            width: Val::Percent(100.0),
+            ..default()
+        },
+        UiTargetCamera(camera),
+        WindowLabel(Timer::from_seconds(
+            WINDOW_LABEL_DURATION_SECS,
+            TimerMode::Once,
+        )),
+    ));
+
+    commands.insert_resource(SecondWindowEntities { window, camera });
+    log.push("Window 2: opened".into());
+}
+
+fn log_window_focus(
+    second: Option<Res<SecondWindowEntities>>,
+    windows: Query<(Entity, &Window)>,
+    mut log: ResMut<EventLog>,
+    mut last_focused: Local<Option<Entity>>,
+) {
+    if second.is_none() {
+        *last_focused = None;
+        return;
+    }
+
+    let current_focused = windows.iter().find(|(_, w)| w.focused).map(|(e, _)| e);
+
+    if current_focused != *last_focused {
+        if let Some(focused) = current_focused {
+            let sw = second.unwrap();
+            let label = if focused == sw.window {
+                "Window 2"
+            } else {
+                "Window 1"
+            };
+            log.push(format!("{label} focused"));
+        }
+        *last_focused = current_focused;
+    }
+}
+
+fn cleanup_second_window(
+    mut commands: Commands,
+    second: Option<Res<SecondWindowEntities>>,
+    windows: Query<(), With<Window>>,
+    mut log: ResMut<EventLog>,
+) {
+    let Some(sw) = second else {
+        return;
+    };
+    // If the window entity no longer has a `Window` component, it was closed by the user
+    if windows.get(sw.window).is_err() {
+        commands.entity(sw.camera).despawn();
+        commands.remove_resource::<SecondWindowEntities>();
+        log.push("Window 2: closed".into());
+    }
+}
+
+fn despawn_window_labels(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut query: Query<(Entity, &mut WindowLabel)>,
+) {
+    for (entity, mut label) in &mut query {
+        label.0.tick(time.delta());
+        if label.0.just_finished() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+// ============================================================================
+// Pause
+// ============================================================================
+
+fn not_paused(time: Res<Time<Virtual>>) -> bool {
+    !time.is_paused()
+}
+
+fn toggle_pause(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut time: ResMut<Time<Virtual>>,
+    mut overlay: Query<&mut Visibility, With<PausedOverlay>>,
+) {
+    if !keyboard.just_pressed(KeyCode::Escape) {
+        return;
+    }
+    if time.is_paused() {
+        time.unpause();
+        for mut vis in &mut overlay {
+            *vis = Visibility::Hidden;
+        }
+    } else {
+        time.pause();
+        for mut vis in &mut overlay {
+            *vis = Visibility::Inherited;
+        }
+    }
+}
+
+// ============================================================================
+// Pointer interaction
+// ============================================================================
+
+fn on_mesh_clicked(
+    click: On<Pointer<Click>>,
+    mut commands: Commands,
+    selected: Query<Entity, With<Selected>>,
+    active_easing: Res<ActiveEasing>,
+    time: Res<Time<Virtual>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    for entity in &selected {
+        commands.entity(entity).remove::<Selected>();
+    }
+
+    let clicked = click.entity;
+    let camera = click.hit.camera;
+    commands.entity(clicked).insert(Selected);
+    commands.trigger(
+        ZoomToFit::new(camera, clicked)
+            .margin(ZOOM_MARGIN_MESH)
+            .duration(Duration::from_millis(ZOOM_DURATION_MS))
+            .easing(active_easing.0),
+    );
+}
+
+fn on_ground_clicked(
+    click: On<Pointer<Click>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    selected: Query<Entity, With<Selected>>,
+    active_easing: Res<ActiveEasing>,
+    time: Res<Time<Virtual>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    for entity in &selected {
+        commands.entity(entity).remove::<Selected>();
+    }
+
+    let camera = click.hit.camera;
+    commands.trigger(
+        ZoomToFit::new(camera, scene.scene_bounds)
+            .margin(ZOOM_MARGIN_SCENE)
+            .duration(Duration::from_millis(ZOOM_DURATION_MS))
+            .easing(active_easing.0),
+    );
+}
+
+fn on_below_clicked(
+    click: On<Pointer<Click>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    selected: Query<Entity, With<Selected>>,
+    active_easing: Res<ActiveEasing>,
+    time: Res<Time<Virtual>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    for entity in &selected {
+        commands.entity(entity).remove::<Selected>();
+    }
+
+    let camera = click.hit.camera;
+    commands.trigger(
+        AnimateToFit::new(camera, scene.scene_bounds)
+            .yaw(CAMERA_START_YAW)
+            .pitch(CAMERA_START_PITCH)
+            .margin(ZOOM_MARGIN_SCENE)
+            .duration(Duration::from_millis(ANIMATE_FIT_DURATION_MS))
+            .easing(active_easing.0),
+    );
+}
+
+fn on_mesh_dragged(
+    drag: On<Pointer<Drag>>,
+    mut transforms: Query<&mut Transform>,
+    time: Res<Time<Virtual>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    if let Ok(mut transform) = transforms.get_mut(drag.entity) {
+        transform.rotate_y(drag.delta.x * DRAG_SENSITIVITY);
+        transform.rotate_x(drag.delta.y * DRAG_SENSITIVITY);
+    }
+}
+
+fn on_mesh_hover(hover: On<Pointer<Over>>, mut hovered: ResMut<HoveredEntity>) {
+    hovered.0 = Some(hover.entity);
+}
+
+fn on_mesh_unhover(hover: On<Pointer<Out>>, mut hovered: ResMut<HoveredEntity>) {
+    if hovered.0 == Some(hover.entity) {
+        hovered.0 = None;
+    }
+}
+
+fn look_at_hovered(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    hovered: Res<HoveredEntity>,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    active_easing: Res<ActiveEasing>,
+    windows: Query<&Window>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyF) {
+        return;
+    }
+    let Some(target) = hovered.0 else {
+        return;
+    };
+    let Some(cam) = focused_camera(&scene, second.as_deref(), &windows) else {
+        return;
+    };
+    commands.trigger(
+        LookAt::new(cam, target)
+            .duration(Duration::from_millis(LOOK_AT_DURATION_MS))
+            .easing(active_easing.0),
+    );
+}
+
+fn look_at_and_zoom_to_fit_hovered(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    hovered: Res<HoveredEntity>,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    active_easing: Res<ActiveEasing>,
+    windows: Query<&Window>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyG) {
+        return;
+    }
+    let Some(target) = hovered.0 else {
+        return;
+    };
+    let Some(cam) = focused_camera(&scene, second.as_deref(), &windows) else {
+        return;
+    };
+    commands.trigger(
+        LookAtAndZoomToFit::new(cam, target)
+            .margin(ZOOM_MARGIN_MESH)
+            .duration(Duration::from_millis(LOOK_AT_DURATION_MS))
+            .easing(active_easing.0),
+    );
+}
+
+// ============================================================================
+// Selection gizmo
+// ============================================================================
+
+fn draw_shape_gizmo(
+    gizmos: &mut Gizmos<SelectionGizmo>,
+    transform: &Transform,
+    shape: &MeshShape,
+    color: Color,
+) {
+    match shape {
+        MeshShape::Cuboid(size) => {
+            gizmos.cube(
+                Transform::from_translation(transform.translation)
+                    .with_rotation(transform.rotation)
+                    .with_scale(*size * GIZMO_SCALE),
+                color,
+            );
+        }
+        MeshShape::Sphere(radius) => {
+            gizmos.sphere(
+                Isometry3d::new(transform.translation, transform.rotation),
+                radius * GIZMO_SCALE,
+                color,
+            );
+        }
+        MeshShape::Torus {
+            minor_radius,
+            major_radius,
+        } => {
+            gizmos.primitive_3d(
+                &Torus::new(*minor_radius * GIZMO_SCALE, *major_radius * GIZMO_SCALE),
+                Isometry3d::new(transform.translation, transform.rotation),
+                color,
+            );
+        }
+    }
+}
+
+fn draw_selection_gizmo(
+    mut gizmos: Gizmos<SelectionGizmo>,
+    query: Query<(&Transform, &MeshShape), With<Selected>>,
+) {
+    let color = Color::from(DEEP_SKY_BLUE);
+    for (transform, shape) in &query {
+        draw_shape_gizmo(&mut gizmos, transform, shape, color);
+    }
+}
+
+fn draw_hover_gizmo(
+    mut gizmos: Gizmos<SelectionGizmo>,
+    hovered: Res<HoveredEntity>,
+    query: Query<(&Transform, &MeshShape), Without<Selected>>,
+) {
+    let Some(entity) = hovered.0 else {
+        return;
+    };
+    let Ok((transform, shape)) = query.get(entity) else {
+        return;
+    };
+    draw_shape_gizmo(&mut gizmos, transform, shape, Color::from(ORANGE));
+}
+
+type GizmoLayerQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        Entity,
+        Option<&'static FitVisualization>,
+        Option<&'static RenderLayers>,
+    ),
+    With<PanOrbitCamera>,
+>;
+
+/// Cameras with `FitVisualization` lose the selection gizmo layer so the outline
+/// doesn't compete with the debug overlay. Cameras without it get the layer back.
+fn sync_selection_gizmo_layers(mut commands: Commands, camera_query: GizmoLayerQuery) {
+    let with_selection = RenderLayers::from_layers(&[0, SELECTION_GIZMO_LAYER]);
+    let without_selection = RenderLayers::layer(0);
+
+    for (entity, has_viz, current_layers) in &camera_query {
+        let desired = if has_viz.is_some() {
+            &without_selection
+        } else {
+            &with_selection
+        };
+        if current_layers != Some(desired) {
+            commands.entity(entity).insert(desired.clone());
+        }
+    }
+}
+
+// ============================================================================
+// Keyboard actions
+// ============================================================================
+
+fn toggle_debug_visualization(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    viz_query: Query<(), With<FitVisualization>>,
+    windows: Query<&Window>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyD) {
+        return;
+    }
+
+    let Some(cam) = focused_camera(&scene, second.as_deref(), &windows) else {
+        return;
+    };
+    if viz_query.get(cam).is_ok() {
+        commands.entity(cam).remove::<FitVisualization>();
+    } else {
+        commands.entity(cam).insert(FitVisualization);
+    }
+}
+
+fn animate_camera(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    easing: Res<ActiveEasing>,
+    camera_query: Query<&PanOrbitCamera>,
+    windows: Query<&Window>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyA) {
+        return;
+    }
+
+    let Some(cam) = focused_camera(&scene, second.as_deref(), &windows) else {
+        return;
+    };
+    let Ok(camera) = camera_query.get(cam) else {
+        return;
+    };
+
+    let e = easing.0;
+    let half_pi = PI / 2.0;
+    let yaw = camera.target_yaw;
+    let pitch = camera.target_pitch;
+    let radius = camera.target_radius;
+    let focus = camera.target_focus;
+
+    let camera_moves = [
+        CameraMove::ToOrbit {
+            focus,
+            yaw: yaw + half_pi,
+            pitch,
+            radius,
+            duration: Duration::from_millis(ORBIT_MOVE_DURATION_MS),
+            easing: e,
+        },
+        CameraMove::ToOrbit {
+            focus,
+            yaw: yaw + half_pi * 2.0,
+            pitch,
+            radius,
+            duration: Duration::from_millis(ORBIT_MOVE_DURATION_MS),
+            easing: e,
+        },
+        CameraMove::ToOrbit {
+            focus,
+            yaw: yaw + half_pi * 3.0,
+            pitch,
+            radius,
+            duration: Duration::from_millis(ORBIT_MOVE_DURATION_MS),
+            easing: e,
+        },
+        CameraMove::ToOrbit {
+            focus,
+            yaw: yaw + half_pi * 4.0,
+            pitch,
+            radius,
+            duration: Duration::from_millis(ORBIT_MOVE_DURATION_MS),
+            easing: e,
+        },
+    ];
+
+    commands.trigger(PlayAnimation::new(cam, camera_moves));
+}
+
+fn randomize_easing(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut easing: ResMut<ActiveEasing>,
+    time: Res<Time>,
+    mut log: ResMut<EventLog>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyR) {
+        let index = (time.elapsed_secs() * 1000.0) as usize % ALL_EASINGS.len();
+        easing.0 = ALL_EASINGS[index];
+        log.push(format!("Easing: {:#?}", easing.0));
+    }
+    if keyboard.just_pressed(KeyCode::KeyE) {
+        easing.0 = EaseFunction::CubicOut;
+        log.push("Easing: reset to CubicOut".into());
+    }
+}
+
+fn animate_fit_to_scene(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    easing: Res<ActiveEasing>,
+    windows: Query<&Window>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyH) {
+        return;
+    }
+
+    let Some(cam) = focused_camera(&scene, second.as_deref(), &windows) else {
+        return;
+    };
+    commands.trigger(
+        AnimateToFit::new(cam, scene.scene_bounds)
+            .yaw(CAMERA_START_YAW)
+            .pitch(CAMERA_START_PITCH)
+            .margin(ZOOM_MARGIN_SCENE)
+            .duration(Duration::from_millis(ANIMATE_FIT_DURATION_MS))
+            .easing(easing.0),
+    );
+}
+
+/// Toggles between perspective and orthographic projection, then re-fits the scene.
+///
+/// The fit is deferred one frame via `pending_fit` because `PanOrbitCamera` needs to
+/// process the projection change (syncing radius ↔ orthographic scale) before the
+/// fit calculation can produce correct results.
+#[allow(clippy::too_many_arguments)]
+fn toggle_projection(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    active_easing: Res<ActiveEasing>,
+    mut camera_query: Query<(&mut Projection, &mut PanOrbitCamera)>,
+    mut log: ResMut<EventLog>,
+    mut pending_fit: Local<bool>,
+) {
+    // Deferred fit: projection was changed last frame, `PanOrbitCamera` has now synced.
+    if *pending_fit {
+        *pending_fit = false;
+        for cam in all_cameras(&scene, second.as_deref()) {
+            commands.trigger(
+                AnimateToFit::new(cam, scene.scene_bounds)
+                    .yaw(CAMERA_START_YAW)
+                    .pitch(CAMERA_START_PITCH)
+                    .margin(ZOOM_MARGIN_SCENE)
+                    .duration(Duration::from_millis(ANIMATE_FIT_DURATION_MS))
+                    .easing(active_easing.0),
+            );
+        }
+        return;
+    }
+
+    if !keyboard.just_pressed(KeyCode::KeyP) {
+        return;
+    }
+    let mut logged = false;
+    for cam in all_cameras(&scene, second.as_deref()) {
+        let Ok((mut projection, mut camera)) = camera_query.get_mut(cam) else {
+            continue;
+        };
+        match *projection {
+            Projection::Perspective(_) => {
+                *projection = Projection::from(OrthographicProjection {
+                    scaling_mode: ScalingMode::FixedVertical {
+                        viewport_height: 1.0,
+                    },
+                    far: 40.0,
+                    ..OrthographicProjection::default_3d()
+                });
+                if !logged {
+                    log.push("Projection: Orthographic".into());
+                    logged = true;
+                }
+            }
+            Projection::Orthographic(_) => {
+                *projection = Projection::Perspective(PerspectiveProjection::default());
+                if !logged {
+                    log.push("Projection: Perspective".into());
+                    logged = true;
+                }
+            }
+            _ => {}
+        }
+        camera.force_update = true;
+    }
+    if logged {
+        *pending_fit = true;
+    }
+}
+
+// ============================================================================
+// Behavior configuration
+// ============================================================================
+
+fn interrupt_behavior_hint_text(behavior: CameraInputInterruptBehavior) -> String {
+    match behavior {
+        CameraInputInterruptBehavior::Ignore => {
+            "CameraInputInterruptBehavior::Ignore - camera input during animation is ignored".into()
+        },
+        CameraInputInterruptBehavior::Cancel => {
+            "CameraInputInterruptBehavior::Cancel - camera input during animation will cancel it".into()
+        },
+        CameraInputInterruptBehavior::Complete => {
+            "CameraInputInterruptBehavior::Complete - camera input during animation will jump to final position"
+                .into()
+        },
+    }
+}
+
+fn toggle_interrupt_behavior(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    mut behavior_query: Query<&mut CameraInputInterruptBehavior>,
+    mut hint_query: Query<&mut Text, With<CameraInputInterruptBehaviorLabel>>,
+    mut log: ResMut<EventLog>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyI) {
+        return;
+    }
+
+    // Determine what the new behavior should be based on the primary camera
+    let new_behavior = match behavior_query.get(scene.camera) {
+        Ok(behavior) => match *behavior {
+            CameraInputInterruptBehavior::Ignore => CameraInputInterruptBehavior::Cancel,
+            CameraInputInterruptBehavior::Cancel => CameraInputInterruptBehavior::Complete,
+            CameraInputInterruptBehavior::Complete => CameraInputInterruptBehavior::Ignore,
+        },
+        Err(_) => CameraInputInterruptBehavior::Ignore,
+    };
+
+    for cam in all_cameras(&scene, second.as_deref()) {
+        if let Ok(mut behavior) = behavior_query.get_mut(cam) {
+            *behavior = new_behavior;
+        } else {
+            commands.entity(cam).insert(new_behavior);
+        }
+    }
+
+    for mut text in &mut hint_query {
+        **text = interrupt_behavior_hint_text(new_behavior);
+    }
+    log.push(format!("CameraInputInterruptBehavior: {new_behavior:?}"));
+}
+
+fn conflict_policy_hint_text(policy: AnimationConflictPolicy) -> String {
+    match policy {
+        AnimationConflictPolicy::LastWins => {
+            "AnimationConflictPolicy::LastWins - new animation cancels current one".into()
+        }
+        AnimationConflictPolicy::FirstWins => {
+            "AnimationConflictPolicy::FirstWins - new animation is rejected while one is playing"
+                .into()
+        }
+    }
+}
+
+fn toggle_animation_conflict_policy(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    scene: Res<SceneEntities>,
+    second: Option<Res<SecondWindowEntities>>,
+    mut policy_query: Query<&mut AnimationConflictPolicy>,
+    mut hint_query: Query<&mut Text, With<AnimationConflictPolicyLabel>>,
+    mut log: ResMut<EventLog>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyQ) {
+        return;
+    }
+
+    // Determine what the new policy should be based on the primary camera
+    let new_policy = match policy_query.get(scene.camera) {
+        Ok(policy) => match *policy {
+            AnimationConflictPolicy::LastWins => AnimationConflictPolicy::FirstWins,
+            AnimationConflictPolicy::FirstWins => AnimationConflictPolicy::LastWins,
+        },
+        Err(_) => AnimationConflictPolicy::FirstWins,
+    };
+
+    for cam in all_cameras(&scene, second.as_deref()) {
+        if let Ok(mut policy) = policy_query.get_mut(cam) {
+            *policy = new_policy;
+        } else {
+            commands.entity(cam).insert(new_policy);
+        }
+    }
+
+    for mut text in &mut hint_query {
+        **text = conflict_policy_hint_text(new_policy);
+    }
+    log.push(format!("AnimationConflictPolicy: {new_policy:?}"));
+}
+
+// ============================================================================
+// Event log
+// ============================================================================
+
+/// Enables the event log when the initial `AnimateToFit` animation completes.
+#[allow(clippy::type_complexity)]
+fn enable_log_on_initial_fit(
+    _trigger: On<AnimationEnd>,
+    mut commands: Commands,
+    marker: Option<Res<EnableLogOnAnimationEnd>>,
+    mut log: ResMut<EventLog>,
+    mut container_query: Query<
+        &mut Visibility,
+        (
+            With<EventLogNode>,
+            Without<EventLogHint>,
+            Without<EventLogToggleHint>,
+        ),
+    >,
+    mut hint_query: Query<
+        &mut Visibility,
+        (
+            With<EventLogHint>,
+            Without<EventLogNode>,
+            Without<EventLogToggleHint>,
+        ),
+    >,
+    mut toggle_hint_query: Query<
+        &mut Visibility,
+        (
+            With<EventLogToggleHint>,
+            Without<EventLogNode>,
+            Without<EventLogHint>,
+        ),
+    >,
+) {
+    if marker.is_none() {
+        return;
+    }
+    commands.remove_resource::<EnableLogOnAnimationEnd>();
+    log.enabled = true;
+    for mut vis in &mut container_query {
+        *vis = Visibility::Inherited;
+    }
+    for mut vis in &mut hint_query {
+        *vis = Visibility::Inherited;
+    }
+    for mut vis in &mut toggle_hint_query {
+        *vis = Visibility::Inherited;
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn toggle_event_log(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    mut log: ResMut<EventLog>,
+    mut container_query: Query<
+        (Entity, &mut Visibility, &mut ScrollPosition),
+        (With<EventLogNode>, Without<EventLogHint>),
+    >,
+    children_query: Query<&Children>,
+    mut hint_query: Query<&mut Visibility, (With<EventLogHint>, Without<EventLogNode>)>,
+) {
+    if !keyboard.just_pressed(KeyCode::KeyL) {
+        return;
+    }
+
+    log.enabled = !log.enabled;
+
+    if log.enabled {
+        for (_, mut vis, _) in &mut container_query {
+            *vis = Visibility::Inherited;
+        }
+        for mut vis in &mut hint_query {
+            *vis = Visibility::Inherited;
+        }
+    } else {
+        // Clear log entries and hide
+        for (entity, mut vis, mut scroll) in &mut container_query {
+            if let Ok(children) = children_query.get(entity) {
+                for child in children.iter() {
+                    commands.entity(child).despawn();
+                }
+            }
+            scroll.y = 0.0;
+            *vis = Visibility::Hidden;
+        }
+        for mut vis in &mut hint_query {
+            *vis = Visibility::Hidden;
+        }
+        log.pending.clear();
+    }
+}
+
+impl EventLog {
+    fn push(&mut self, text: String) {
+        if !self.enabled {
+            return;
+        }
+        self.pending.push(PendingLogEntry {
+            text,
+            color: EVENT_LOG_COLOR,
+        });
+    }
+
+    fn push_red(&mut self, text: String) {
+        if !self.enabled {
+            return;
+        }
+        self.pending.push(PendingLogEntry {
+            text,
+            color: EVENT_LOG_COLOR_RED,
+        });
+    }
+
+    fn separator(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.pending.push(PendingLogEntry {
+            text: EVENT_LOG_SEPARATOR.into(),
+            color: EVENT_LOG_COLOR,
+        });
+    }
+}
+
+fn fmt_vec3(v: Vec3) -> String {
+    format!("({:.1}, {:.1}, {:.1})", v.x, v.y, v.z)
+}
+
+fn log_animation_begin(event: On<AnimationBegin>, mut log: ResMut<EventLog>) {
+    log.push(format!("AnimationBegin\n  source={:?}", event.source));
+}
+
+fn log_animation_end(event: On<AnimationEnd>, mut log: ResMut<EventLog>) {
+    log.push(format!("AnimationEnd\n  source={:?}", event.source));
+    if event.source != AnimationSource::ZoomToFit {
+        log.separator();
+    }
+}
+
+fn log_camera_move_start(event: On<CameraMoveBegin>, mut log: ResMut<EventLog>) {
+    log.push(format!(
+        "CameraMoveBegin\n  translation={}\n  focus={}\n  duration={:.0}ms\n  easing={:?}",
+        fmt_vec3(event.camera_move.translation()),
+        fmt_vec3(event.camera_move.focus()),
+        event.camera_move.duration_ms(),
+        event.camera_move.easing(),
+    ));
+}
+
+fn log_camera_move_end(_event: On<CameraMoveEnd>, mut log: ResMut<EventLog>) {
+    log.push("CameraMoveEnd".into());
+}
+
+fn log_zoom_begin(event: On<ZoomBegin>, mut log: ResMut<EventLog>) {
+    log.push(format!(
+        "ZoomBegin\n  margin={:.2}\n  duration={:.0}ms\n  easing={:?}",
+        event.margin,
+        event.duration.as_secs_f32() * 1000.0,
+        event.easing,
+    ));
+}
+
+fn log_zoom_end(_event: On<ZoomEnd>, mut log: ResMut<EventLog>) {
+    log.push("ZoomEnd".into());
+    log.separator();
+}
+
+fn log_animation_cancelled(event: On<AnimationCancelled>, mut log: ResMut<EventLog>) {
+    log.push_red(format!(
+        "AnimationCancelled\n  source={:?}\n  move_translation={}\n  move_focus={}",
+        event.source,
+        fmt_vec3(event.camera_move.translation()),
+        fmt_vec3(event.camera_move.focus()),
+    ));
+}
+
+fn log_zoom_cancelled(_event: On<ZoomCancelled>, mut log: ResMut<EventLog>) {
+    log.push_red("ZoomCancelled".into());
+}
+
+fn log_animation_rejected(event: On<AnimationRejected>, mut log: ResMut<EventLog>) {
+    log.push_red(format!("AnimationRejected\n  source={:?}", event.source));
+}
+
+/// Spawns pending log entries as child `Text` nodes inside the scroll container
+/// and auto-scrolls to the bottom.
+fn update_event_log_text(
+    mut commands: Commands,
+    mut log: ResMut<EventLog>,
+    container_query: Query<(Entity, &Node, &ComputedNode), With<EventLogNode>>,
+    mut scroll_query: Query<&mut ScrollPosition, With<EventLogNode>>,
+) {
+    if log.pending.is_empty() {
+        return;
+    }
+
+    let Ok((container, _node, computed)) = container_query.single() else {
+        return;
+    };
+
+    for entry in log.pending.drain(..) {
+        commands.entity(container).with_child((
+            Text::new(entry.text),
+            TextFont {
+                font_size: EVENT_LOG_FONT_SIZE,
+                ..default()
+            },
+            TextColor(entry.color),
+        ));
+    }
+
+    // Auto-scroll to bottom
+    if let Ok(mut scroll) = scroll_query.single_mut() {
+        let content_height = computed.content_size().y;
+        let container_height = computed.size().y;
+        let max_scroll =
+            (content_height - container_height).max(0.0) * computed.inverse_scale_factor();
+        scroll.y = max_scroll + EVENT_LOG_SCROLL_SPEED * 4.0;
+    }
+}
+
+/// Scrolls the event log with Up/Down arrow keys, clears with 'C'.
+fn scroll_event_log(
+    mut commands: Commands,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut scroll_query: Query<(Entity, &mut ScrollPosition, &ComputedNode), With<EventLogNode>>,
+    children_query: Query<&Children>,
+) {
+    let Ok((container, mut scroll, computed)) = scroll_query.single_mut() else {
+        return;
+    };
+
+    if keyboard.just_pressed(KeyCode::KeyC) {
+        if let Ok(children) = children_query.get(container) {
+            for child in children.iter() {
+                commands.entity(child).despawn();
+            }
+        }
+        scroll.y = 0.0;
+        return;
+    }
+
+    let dy = if keyboard.pressed(KeyCode::ArrowDown) {
+        EVENT_LOG_SCROLL_SPEED
+    } else if keyboard.pressed(KeyCode::ArrowUp) {
+        -EVENT_LOG_SCROLL_SPEED
+    } else {
+        return;
+    };
+
+    let max_scroll =
+        (computed.content_size().y - computed.size().y).max(0.0) * computed.inverse_scale_factor();
+    scroll.y = (scroll.y + dy).clamp(0.0, max_scroll);
+}

--- a/examples/extras_animate_to_fit.rs
+++ b/examples/extras_animate_to_fit.rs
@@ -1,0 +1,116 @@
+//! Demonstrates `AnimateToFit` — animates the camera to a specific orientation
+//! while framing a target entity.
+//!
+//! Controls:
+//!   Space — AnimateToFit with yaw=45° pitch=30°
+//!   R     — Reset camera
+//!
+//! Observe AnimationBegin and AnimationEnd via info!() logging.
+
+use std::f32::consts::TAU;
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::AnimateToFit;
+use bevy_panorbit_camera::AnimationBegin;
+use bevy_panorbit_camera::AnimationEnd;
+use bevy_panorbit_camera::PanOrbitCamera;
+use bevy_panorbit_camera::PanOrbitCameraPlugin;
+
+#[derive(Component)]
+struct Target;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, keyboard_input)
+        .add_observer(on_animation_begin)
+        .add_observer(on_animation_end)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(10.0, 10.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // Target cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.5, 1.5, 1.5))),
+        MeshMaterial3d(materials.add(Color::srgb(0.2, 0.4, 0.8))),
+        Transform::from_xyz(0.0, 0.75, 0.0),
+        Target,
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    commands.spawn((
+        Transform::from_xyz(0.0, 3.0, 8.0),
+        PanOrbitCamera::default(),
+    ));
+
+    info!("Press Space to AnimateToFit (yaw=45 pitch=30), R to reset");
+}
+
+fn keyboard_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    camera_query: Query<Entity, With<PanOrbitCamera>>,
+    target_query: Query<Entity, With<Target>>,
+    mut pan_orbit_query: Query<&mut PanOrbitCamera>,
+) {
+    let Ok(camera) = camera_query.single() else {
+        return;
+    };
+    let Ok(target) = target_query.single() else {
+        return;
+    };
+
+    if keys.just_pressed(KeyCode::Space) {
+        commands.trigger(
+            AnimateToFit::new(camera, target)
+                .yaw(TAU / 8.0)
+                .pitch(TAU / 12.0)
+                .margin(0.15)
+                .duration(Duration::from_millis(1200)),
+        );
+    }
+
+    if keys.just_pressed(KeyCode::KeyR) {
+        if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            pan_orbit.target_focus = Vec3::ZERO;
+            pan_orbit.target_yaw = 0.0;
+            pan_orbit.target_pitch = 0.0;
+            pan_orbit.target_radius = 8.0;
+            pan_orbit.force_update = true;
+            info!("Camera reset");
+        }
+    }
+}
+
+fn on_animation_begin(trigger: On<AnimationBegin>) {
+    info!(
+        "AnimationBegin: camera={:?} source={:?}",
+        trigger.camera, trigger.source
+    );
+}
+
+fn on_animation_end(trigger: On<AnimationEnd>) {
+    info!(
+        "AnimationEnd: camera={:?} source={:?}",
+        trigger.camera, trigger.source
+    );
+}

--- a/examples/extras_animate_to_fit.rs
+++ b/examples/extras_animate_to_fit.rs
@@ -16,6 +16,9 @@ use bevy_panorbit_camera::AnimationBegin;
 use bevy_panorbit_camera::AnimationEnd;
 use bevy_panorbit_camera::PanOrbitCamera;
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::TrackpadBehavior;
+
+const START_POS: Vec3 = Vec3::new(0.0, 3.0, 8.0);
 
 #[derive(Component)]
 struct Target;
@@ -44,7 +47,7 @@ fn setup(
     // Target cube
     commands.spawn((
         Mesh3d(meshes.add(Cuboid::new(1.5, 1.5, 1.5))),
-        MeshMaterial3d(materials.add(Color::srgb(0.2, 0.4, 0.8))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
         Transform::from_xyz(0.0, 0.75, 0.0),
         Target,
     ));
@@ -58,11 +61,21 @@ fn setup(
     ));
     // Camera
     commands.spawn((
-        Transform::from_xyz(0.0, 3.0, 8.0),
-        PanOrbitCamera::default(),
+        Transform::from_translation(START_POS),
+        PanOrbitCamera {
+            trackpad_behavior: TrackpadBehavior::BlenderLike {
+                modifier_pan: Some(KeyCode::ShiftLeft),
+                modifier_zoom: Some(KeyCode::ControlLeft),
+            },
+            trackpad_pinch_to_zoom_enabled: true,
+            ..default()
+        },
     ));
 
-    info!("Press Space to AnimateToFit (yaw=45 pitch=30), R to reset");
+    // Instructions
+    commands.spawn(Text::new(
+        "Space - AnimateToFit the cube (yaw=45 pitch=30)\nR - Reset camera",
+    ));
 }
 
 fn keyboard_input(
@@ -91,10 +104,11 @@ fn keyboard_input(
 
     if keys.just_pressed(KeyCode::KeyR) {
         if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            let radius = START_POS.length();
             pan_orbit.target_focus = Vec3::ZERO;
-            pan_orbit.target_yaw = 0.0;
-            pan_orbit.target_pitch = 0.0;
-            pan_orbit.target_radius = 8.0;
+            pan_orbit.target_yaw = f32::atan2(START_POS.x, START_POS.z);
+            pan_orbit.target_pitch = f32::asin(START_POS.y / radius);
+            pan_orbit.target_radius = radius;
             pan_orbit.force_update = true;
             info!("Camera reset");
         }

--- a/examples/extras_look_at.rs
+++ b/examples/extras_look_at.rs
@@ -1,11 +1,14 @@
-//! Demonstrates `LookAt` and `LookAtAndZoomToFit`.
+//! Demonstrates `LookAt`, `LookAtAndZoomToFit`, and `ZoomToFit`.
 //!
 //! Controls:
-//!   L — LookAt the target (rotates camera in place)
-//!   K — LookAtAndZoomToFit (rotates + frames the target)
+//!   L — LookAt the red cube (rotates camera in place)
+//!   K — LookAtAndZoomToFit the red cube (rotates + frames)
+//!   Z — ZoomToFit the red cube (frames without changing look direction)
 //!   R — Reset camera
 //!
-//! Shows the difference: LookAt only rotates, LookAtAndZoomToFit also adjusts radius.
+//! Compare K vs Z: both frame the target, but LookAtAndZoomToFit also
+//! changes the orbit focus to the target, while ZoomToFit keeps the
+//! current focus and only adjusts radius.
 
 use std::time::Duration;
 
@@ -16,6 +19,11 @@ use bevy_panorbit_camera::LookAt;
 use bevy_panorbit_camera::LookAtAndZoomToFit;
 use bevy_panorbit_camera::PanOrbitCamera;
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::TrackpadBehavior;
+use bevy_panorbit_camera::ZoomToFit;
+
+// Camera starts close to the gray cube, with the red cube barely visible on the right
+const START_POS: Vec3 = Vec3::new(0.0, 1.5, 3.0);
 
 #[derive(Component)]
 struct Target;
@@ -41,14 +49,14 @@ fn setup(
         Mesh3d(meshes.add(Plane3d::default().mesh().size(10.0, 10.0))),
         MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
     ));
-    // Target sphere — off to the side so LookAt is visible
+    // Target cube — off to the right so it's barely in view
     commands.spawn((
-        Mesh3d(meshes.add(Sphere::new(0.5).mesh().uv(32, 18))),
-        MeshMaterial3d(materials.add(Color::srgb(0.9, 0.3, 0.1))),
-        Transform::from_xyz(4.0, 1.0, -3.0),
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(3.5, 0.5, 0.0),
         Target,
     ));
-    // Reference cube at origin
+    // Gray cube near origin — what the camera starts focused on
     commands.spawn((
         Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
         MeshMaterial3d(materials.add(Color::srgb(0.5, 0.5, 0.5))),
@@ -62,13 +70,26 @@ fn setup(
         },
         Transform::from_xyz(4.0, 8.0, 4.0),
     ));
-    // Camera — pointed at origin, target is off to the side
+    // Camera — close to the gray cube, red cube just visible on the right
     commands.spawn((
-        Transform::from_xyz(0.0, 3.0, 8.0),
-        PanOrbitCamera::default(),
+        Transform::from_translation(START_POS),
+        PanOrbitCamera {
+            trackpad_behavior: TrackpadBehavior::BlenderLike {
+                modifier_pan: Some(KeyCode::ShiftLeft),
+                modifier_zoom: Some(KeyCode::ControlLeft),
+            },
+            trackpad_pinch_to_zoom_enabled: true,
+            ..default()
+        },
     ));
 
-    info!("Press L to LookAt, K to LookAtAndZoomToFit, R to reset");
+    // Instructions
+    commands.spawn(Text::new(
+        "L - LookAt the cube (rotates camera only)\n\
+         K - LookAtAndZoomToFit the cube (rotates + frames)\n\
+         Z - ZoomToFit the cube (frames without rotating)\n\
+         R - Reset camera",
+    ));
 }
 
 fn keyboard_input(
@@ -87,24 +108,34 @@ fn keyboard_input(
 
     if keys.just_pressed(KeyCode::KeyL) {
         commands.trigger(LookAt::new(camera, target).duration(Duration::from_millis(600)));
-        info!("LookAt triggered — camera rotates to face target");
+        info!("LookAt triggered");
     }
 
     if keys.just_pressed(KeyCode::KeyK) {
         commands.trigger(
             LookAtAndZoomToFit::new(camera, target)
-                .margin(0.2)
+                .margin(0.15)
                 .duration(Duration::from_millis(800)),
         );
-        info!("LookAtAndZoomToFit triggered — camera rotates and frames target");
+        info!("LookAtAndZoomToFit triggered");
+    }
+
+    if keys.just_pressed(KeyCode::KeyZ) {
+        commands.trigger(
+            ZoomToFit::new(camera, target)
+                .margin(0.15)
+                .duration(Duration::from_millis(800)),
+        );
+        info!("ZoomToFit triggered");
     }
 
     if keys.just_pressed(KeyCode::KeyR) {
         if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            let radius = START_POS.length();
             pan_orbit.target_focus = Vec3::ZERO;
-            pan_orbit.target_yaw = 0.0;
-            pan_orbit.target_pitch = 0.0;
-            pan_orbit.target_radius = 8.0;
+            pan_orbit.target_yaw = f32::atan2(START_POS.x, START_POS.z);
+            pan_orbit.target_pitch = f32::asin(START_POS.y / radius);
+            pan_orbit.target_radius = radius;
             pan_orbit.force_update = true;
             info!("Camera reset");
         }

--- a/examples/extras_look_at.rs
+++ b/examples/extras_look_at.rs
@@ -1,0 +1,120 @@
+//! Demonstrates `LookAt` and `LookAtAndZoomToFit`.
+//!
+//! Controls:
+//!   L — LookAt the target (rotates camera in place)
+//!   K — LookAtAndZoomToFit (rotates + frames the target)
+//!   R — Reset camera
+//!
+//! Shows the difference: LookAt only rotates, LookAtAndZoomToFit also adjusts radius.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::AnimationBegin;
+use bevy_panorbit_camera::AnimationEnd;
+use bevy_panorbit_camera::LookAt;
+use bevy_panorbit_camera::LookAtAndZoomToFit;
+use bevy_panorbit_camera::PanOrbitCamera;
+use bevy_panorbit_camera::PanOrbitCameraPlugin;
+
+#[derive(Component)]
+struct Target;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, keyboard_input)
+        .add_observer(on_animation_begin)
+        .add_observer(on_animation_end)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(10.0, 10.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // Target sphere — off to the side so LookAt is visible
+    commands.spawn((
+        Mesh3d(meshes.add(Sphere::new(0.5).mesh().uv(32, 18))),
+        MeshMaterial3d(materials.add(Color::srgb(0.9, 0.3, 0.1))),
+        Transform::from_xyz(4.0, 1.0, -3.0),
+        Target,
+    ));
+    // Reference cube at origin
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
+        MeshMaterial3d(materials.add(Color::srgb(0.5, 0.5, 0.5))),
+        Transform::from_xyz(0.0, 0.25, 0.0),
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera — pointed at origin, target is off to the side
+    commands.spawn((
+        Transform::from_xyz(0.0, 3.0, 8.0),
+        PanOrbitCamera::default(),
+    ));
+
+    info!("Press L to LookAt, K to LookAtAndZoomToFit, R to reset");
+}
+
+fn keyboard_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    camera_query: Query<Entity, With<PanOrbitCamera>>,
+    target_query: Query<Entity, With<Target>>,
+    mut pan_orbit_query: Query<&mut PanOrbitCamera>,
+) {
+    let Ok(camera) = camera_query.single() else {
+        return;
+    };
+    let Ok(target) = target_query.single() else {
+        return;
+    };
+
+    if keys.just_pressed(KeyCode::KeyL) {
+        commands.trigger(LookAt::new(camera, target).duration(Duration::from_millis(600)));
+        info!("LookAt triggered — camera rotates to face target");
+    }
+
+    if keys.just_pressed(KeyCode::KeyK) {
+        commands.trigger(
+            LookAtAndZoomToFit::new(camera, target)
+                .margin(0.2)
+                .duration(Duration::from_millis(800)),
+        );
+        info!("LookAtAndZoomToFit triggered — camera rotates and frames target");
+    }
+
+    if keys.just_pressed(KeyCode::KeyR) {
+        if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            pan_orbit.target_focus = Vec3::ZERO;
+            pan_orbit.target_yaw = 0.0;
+            pan_orbit.target_pitch = 0.0;
+            pan_orbit.target_radius = 8.0;
+            pan_orbit.force_update = true;
+            info!("Camera reset");
+        }
+    }
+}
+
+fn on_animation_begin(trigger: On<AnimationBegin>) {
+    info!("AnimationBegin: source={:?}", trigger.source);
+}
+
+fn on_animation_end(trigger: On<AnimationEnd>) {
+    info!("AnimationEnd: source={:?}", trigger.source);
+}

--- a/examples/extras_play_animation.rs
+++ b/examples/extras_play_animation.rs
@@ -1,7 +1,7 @@
 //! Demonstrates `PlayAnimation` — plays a queued sequence of camera movements.
 //!
 //! Controls:
-//!   Space — Play a 3-step camera animation sequence
+//!   Space — Play a 5-step camera animation sequence
 //!   R     — Reset camera
 //!
 //! Observe CameraMoveBegin/CameraMoveEnd for each step via info!() logging.
@@ -16,6 +16,9 @@ use bevy_panorbit_camera::CameraMoveEnd;
 use bevy_panorbit_camera::PanOrbitCamera;
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
 use bevy_panorbit_camera::PlayAnimation;
+use bevy_panorbit_camera::TrackpadBehavior;
+
+const START_POS: Vec3 = Vec3::new(0.0, 2.0, 6.0);
 
 fn main() {
     App::new()
@@ -54,11 +57,21 @@ fn setup(
     ));
     // Camera
     commands.spawn((
-        Transform::from_xyz(0.0, 2.0, 6.0),
-        PanOrbitCamera::default(),
+        Transform::from_translation(START_POS),
+        PanOrbitCamera {
+            trackpad_behavior: TrackpadBehavior::BlenderLike {
+                modifier_pan: Some(KeyCode::ShiftLeft),
+                modifier_zoom: Some(KeyCode::ControlLeft),
+            },
+            trackpad_pinch_to_zoom_enabled: true,
+            ..default()
+        },
     ));
 
-    info!("Press Space to play a 3-step animation, R to reset");
+    // Instructions
+    commands.spawn(Text::new(
+        "Space - Play 5-step animation sequence\nR - Reset camera",
+    ));
 }
 
 fn keyboard_input(
@@ -72,33 +85,52 @@ fn keyboard_input(
     };
 
     if keys.just_pressed(KeyCode::Space) {
+        let focus = Vec3::new(0.0, 0.5, 0.0);
         let moves = [
-            // Step 1: orbit to the right
+            // Step 1: orbit to the side and slightly closer
             CameraMove::ToOrbit {
-                focus: Vec3::new(0.0, 0.5, 0.0),
-                yaw: 1.2,
-                pitch: 0.3,
-                radius: 5.0,
+                focus,
+                yaw: 1.5,
+                pitch: 0.2,
+                radius: 4.0,
                 duration: Duration::from_millis(800),
                 easing: EaseFunction::CubicInOut,
             },
-            // Step 2: swoop up high
+            // Step 2: dramatic zoom out — pull way back and high overhead
             CameraMove::ToOrbit {
-                focus: Vec3::new(0.0, 0.5, 0.0),
+                focus,
                 yaw: 2.5,
-                pitch: 1.0,
-                radius: 4.0,
-                duration: Duration::from_millis(600),
+                pitch: 1.3,
+                radius: 20.0,
+                duration: Duration::from_millis(1200),
+                easing: EaseFunction::CubicIn,
+            },
+            // Step 3: sweep around to the opposite side while staying wide
+            CameraMove::ToOrbit {
+                focus,
+                yaw: 4.5,
+                pitch: 0.6,
+                radius: 14.0,
+                duration: Duration::from_millis(1200),
                 easing: EaseFunction::SineInOut,
             },
-            // Step 3: settle back to front view
+            // Step 4: dramatic zoom back in — swoop down close
             CameraMove::ToOrbit {
-                focus: Vec3::new(0.0, 0.5, 0.0),
+                focus,
+                yaw: 5.5,
+                pitch: 0.1,
+                radius: 2.0,
+                duration: Duration::from_millis(1000),
+                easing: EaseFunction::CubicIn,
+            },
+            // Step 5: bounce back to starting view
+            CameraMove::ToOrbit {
+                focus,
                 yaw: 0.0,
                 pitch: 0.3,
                 radius: 6.0,
-                duration: Duration::from_millis(1000),
-                easing: EaseFunction::CubicOut,
+                duration: Duration::from_millis(1200),
+                easing: EaseFunction::BounceOut,
             },
         ];
 
@@ -107,10 +139,11 @@ fn keyboard_input(
 
     if keys.just_pressed(KeyCode::KeyR) {
         if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            let radius = START_POS.length();
             pan_orbit.target_focus = Vec3::ZERO;
-            pan_orbit.target_yaw = 0.0;
-            pan_orbit.target_pitch = 0.0;
-            pan_orbit.target_radius = 6.0;
+            pan_orbit.target_yaw = f32::atan2(START_POS.x, START_POS.z);
+            pan_orbit.target_pitch = f32::asin(START_POS.y / radius);
+            pan_orbit.target_radius = radius;
             pan_orbit.force_update = true;
             info!("Camera reset");
         }

--- a/examples/extras_play_animation.rs
+++ b/examples/extras_play_animation.rs
@@ -1,0 +1,134 @@
+//! Demonstrates `PlayAnimation` — plays a queued sequence of camera movements.
+//!
+//! Controls:
+//!   Space — Play a 3-step camera animation sequence
+//!   R     — Reset camera
+//!
+//! Observe CameraMoveBegin/CameraMoveEnd for each step via info!() logging.
+
+use std::time::Duration;
+
+use bevy::math::curve::easing::EaseFunction;
+use bevy::prelude::*;
+use bevy_panorbit_camera::CameraMove;
+use bevy_panorbit_camera::CameraMoveBegin;
+use bevy_panorbit_camera::CameraMoveEnd;
+use bevy_panorbit_camera::PanOrbitCamera;
+use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::PlayAnimation;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, keyboard_input)
+        .add_observer(on_move_begin)
+        .add_observer(on_move_end)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(10.0, 10.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // Cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    commands.spawn((
+        Transform::from_xyz(0.0, 2.0, 6.0),
+        PanOrbitCamera::default(),
+    ));
+
+    info!("Press Space to play a 3-step animation, R to reset");
+}
+
+fn keyboard_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    camera_query: Query<Entity, With<PanOrbitCamera>>,
+    mut pan_orbit_query: Query<&mut PanOrbitCamera>,
+) {
+    let Ok(camera) = camera_query.single() else {
+        return;
+    };
+
+    if keys.just_pressed(KeyCode::Space) {
+        let moves = [
+            // Step 1: orbit to the right
+            CameraMove::ToOrbit {
+                focus: Vec3::new(0.0, 0.5, 0.0),
+                yaw: 1.2,
+                pitch: 0.3,
+                radius: 5.0,
+                duration: Duration::from_millis(800),
+                easing: EaseFunction::CubicInOut,
+            },
+            // Step 2: swoop up high
+            CameraMove::ToOrbit {
+                focus: Vec3::new(0.0, 0.5, 0.0),
+                yaw: 2.5,
+                pitch: 1.0,
+                radius: 4.0,
+                duration: Duration::from_millis(600),
+                easing: EaseFunction::SineInOut,
+            },
+            // Step 3: settle back to front view
+            CameraMove::ToOrbit {
+                focus: Vec3::new(0.0, 0.5, 0.0),
+                yaw: 0.0,
+                pitch: 0.3,
+                radius: 6.0,
+                duration: Duration::from_millis(1000),
+                easing: EaseFunction::CubicOut,
+            },
+        ];
+
+        commands.trigger(PlayAnimation::new(camera, moves));
+    }
+
+    if keys.just_pressed(KeyCode::KeyR) {
+        if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            pan_orbit.target_focus = Vec3::ZERO;
+            pan_orbit.target_yaw = 0.0;
+            pan_orbit.target_pitch = 0.0;
+            pan_orbit.target_radius = 6.0;
+            pan_orbit.force_update = true;
+            info!("Camera reset");
+        }
+    }
+}
+
+fn on_move_begin(trigger: On<CameraMoveBegin>) {
+    info!(
+        "CameraMoveBegin: camera={:?} duration={:?}",
+        trigger.camera,
+        trigger.camera_move.duration()
+    );
+}
+
+fn on_move_end(trigger: On<CameraMoveEnd>) {
+    info!(
+        "CameraMoveEnd: camera={:?} duration={:?}",
+        trigger.camera,
+        trigger.camera_move.duration()
+    );
+}

--- a/examples/extras_zoom_to_fit.rs
+++ b/examples/extras_zoom_to_fit.rs
@@ -2,6 +2,7 @@
 //!
 //! Controls:
 //!   Space — ZoomToFit the cube (animated)
+//!   D     — Toggle debug visualization
 //!   R     — Reset camera to starting position
 //!
 //! Observe ZoomBegin, ZoomEnd, ZoomCancelled via info!() logging.
@@ -11,11 +12,16 @@ use std::time::Duration;
 use bevy::prelude::*;
 use bevy_panorbit_camera::AnimationEnd;
 use bevy_panorbit_camera::AnimationSource;
+use bevy_panorbit_camera::FitVisualization;
 use bevy_panorbit_camera::PanOrbitCamera;
 use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::SetFitTarget;
+use bevy_panorbit_camera::TrackpadBehavior;
 use bevy_panorbit_camera::ZoomBegin;
 use bevy_panorbit_camera::ZoomEnd;
 use bevy_panorbit_camera::ZoomToFit;
+
+const START_POS: Vec3 = Vec3::new(0.0, 3.0, 8.0);
 
 #[derive(Component)]
 struct Target;
@@ -25,7 +31,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(PanOrbitCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, keyboard_input)
+        .add_systems(Update, (keyboard_input, toggle_debug_visualization))
         .add_observer(on_zoom_begin)
         .add_observer(on_zoom_end)
         .add_observer(on_animation_end)
@@ -45,7 +51,7 @@ fn setup(
     // Target cube
     commands.spawn((
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
-        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.2, 0.2))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
         Transform::from_xyz(3.0, 0.5, -2.0),
         Target,
     ));
@@ -59,11 +65,21 @@ fn setup(
     ));
     // Camera
     commands.spawn((
-        Transform::from_xyz(0.0, 3.0, 8.0),
-        PanOrbitCamera::default(),
+        Transform::from_translation(START_POS),
+        PanOrbitCamera {
+            trackpad_behavior: TrackpadBehavior::BlenderLike {
+                modifier_pan: Some(KeyCode::ShiftLeft),
+                modifier_zoom: Some(KeyCode::ControlLeft),
+            },
+            trackpad_pinch_to_zoom_enabled: true,
+            ..default()
+        },
     ));
 
-    info!("Press Space to ZoomToFit the red cube, R to reset");
+    // Instructions
+    commands.spawn(Text::new(
+        "Space - ZoomToFit the cube\nD - Toggle debug visualization\nR - Reset camera",
+    ));
 }
 
 fn keyboard_input(
@@ -90,10 +106,11 @@ fn keyboard_input(
 
     if keys.just_pressed(KeyCode::KeyR) {
         if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            let radius = START_POS.length();
             pan_orbit.target_focus = Vec3::ZERO;
-            pan_orbit.target_yaw = 0.0;
-            pan_orbit.target_pitch = 0.0;
-            pan_orbit.target_radius = 8.0;
+            pan_orbit.target_yaw = f32::atan2(START_POS.x, START_POS.z);
+            pan_orbit.target_pitch = f32::asin(START_POS.y / radius);
+            pan_orbit.target_radius = radius;
             pan_orbit.force_update = true;
             info!("Camera reset");
         }
@@ -117,5 +134,29 @@ fn on_zoom_end(trigger: On<ZoomEnd>) {
 fn on_animation_end(trigger: On<AnimationEnd>) {
     if trigger.source == AnimationSource::ZoomToFit {
         info!("Animation backing the ZoomToFit completed");
+    }
+}
+
+fn toggle_debug_visualization(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    camera_query: Query<(Entity, Option<&FitVisualization>), With<PanOrbitCamera>>,
+    target_query: Query<Entity, With<Target>>,
+) {
+    if !keys.just_pressed(KeyCode::KeyD) {
+        return;
+    }
+    let Ok(target) = target_query.single() else {
+        return;
+    };
+    for (camera, viz) in &camera_query {
+        if viz.is_some() {
+            commands.entity(camera).remove::<FitVisualization>();
+            info!("Debug visualization OFF");
+        } else {
+            commands.trigger(SetFitTarget::new(camera, target));
+            commands.entity(camera).insert(FitVisualization);
+            info!("Debug visualization ON");
+        }
     }
 }

--- a/examples/extras_zoom_to_fit.rs
+++ b/examples/extras_zoom_to_fit.rs
@@ -1,0 +1,121 @@
+//! Demonstrates `ZoomToFit` — frames a target entity in the camera view.
+//!
+//! Controls:
+//!   Space — ZoomToFit the cube (animated)
+//!   R     — Reset camera to starting position
+//!
+//! Observe ZoomBegin, ZoomEnd, ZoomCancelled via info!() logging.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_panorbit_camera::AnimationEnd;
+use bevy_panorbit_camera::AnimationSource;
+use bevy_panorbit_camera::PanOrbitCamera;
+use bevy_panorbit_camera::PanOrbitCameraPlugin;
+use bevy_panorbit_camera::ZoomBegin;
+use bevy_panorbit_camera::ZoomEnd;
+use bevy_panorbit_camera::ZoomToFit;
+
+#[derive(Component)]
+struct Target;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, keyboard_input)
+        .add_observer(on_zoom_begin)
+        .add_observer(on_zoom_end)
+        .add_observer(on_animation_end)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Ground
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(10.0, 10.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // Target cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.2, 0.2))),
+        Transform::from_xyz(3.0, 0.5, -2.0),
+        Target,
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    commands.spawn((
+        Transform::from_xyz(0.0, 3.0, 8.0),
+        PanOrbitCamera::default(),
+    ));
+
+    info!("Press Space to ZoomToFit the red cube, R to reset");
+}
+
+fn keyboard_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut commands: Commands,
+    camera_query: Query<Entity, With<PanOrbitCamera>>,
+    target_query: Query<Entity, With<Target>>,
+    mut pan_orbit_query: Query<&mut PanOrbitCamera>,
+) {
+    let Ok(camera) = camera_query.single() else {
+        return;
+    };
+    let Ok(target) = target_query.single() else {
+        return;
+    };
+
+    if keys.just_pressed(KeyCode::Space) {
+        commands.trigger(
+            ZoomToFit::new(camera, target)
+                .margin(0.15)
+                .duration(Duration::from_millis(800)),
+        );
+    }
+
+    if keys.just_pressed(KeyCode::KeyR) {
+        if let Ok(mut pan_orbit) = pan_orbit_query.get_mut(camera) {
+            pan_orbit.target_focus = Vec3::ZERO;
+            pan_orbit.target_yaw = 0.0;
+            pan_orbit.target_pitch = 0.0;
+            pan_orbit.target_radius = 8.0;
+            pan_orbit.force_update = true;
+            info!("Camera reset");
+        }
+    }
+}
+
+fn on_zoom_begin(trigger: On<ZoomBegin>) {
+    info!(
+        "ZoomBegin: camera={:?} target={:?} margin={:.2}",
+        trigger.camera, trigger.target, trigger.margin
+    );
+}
+
+fn on_zoom_end(trigger: On<ZoomEnd>) {
+    info!(
+        "ZoomEnd: camera={:?} target={:?}",
+        trigger.camera, trigger.target
+    );
+}
+
+fn on_animation_end(trigger: On<AnimationEnd>) {
+    if trigger.source == AnimationSource::ZoomToFit {
+        info!("Animation backing the ZoomToFit completed");
+    }
+}

--- a/src/extras/animation.rs
+++ b/src/extras/animation.rs
@@ -187,7 +187,7 @@ impl MoveState {
 /// The system will automatically process them one by one, removing the component
 /// when the queue is empty.
 ///
-/// Camera smoothing is automatically disabled while camera_moves are in progress and
+/// Camera smoothing is automatically disabled while `camera_moves` are in progress and
 /// restored when the queue completes via the `restore_camera_state` observer.
 #[derive(Component, Reflect, Default)]
 #[require(CameraInputInterruptBehavior)]
@@ -207,7 +207,7 @@ impl CameraMoveList {
         }
     }
 
-    /// Calculates total remaining time in milliseconds for all queued camera_moves.
+    /// Calculates total remaining time in milliseconds for all queued `camera_moves`.
     pub fn remaining_time_ms(&self) -> f32 {
         // Get remaining time for current move
         let current_remaining = match &self.state {

--- a/src/extras/animation.rs
+++ b/src/extras/animation.rs
@@ -1,0 +1,548 @@
+//! Camera movement queue and animation system.
+//! Allows for simple animation of camera movements with easing functions.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use bevy::math::curve::easing::EaseFunction;
+use bevy::math::curve::Curve;
+use bevy::prelude::*;
+
+use super::components::AnimationSourceMarker;
+use super::components::CameraInputInterruptBehavior;
+use super::components::ZoomAnimationMarker;
+use super::events::AnimationCancelled;
+use super::events::AnimationEnd;
+use super::events::AnimationSource;
+use super::events::CameraMoveBegin;
+use super::events::CameraMoveEnd;
+use super::events::ZoomCancelled;
+use super::events::ZoomEnd;
+use crate::PanOrbitCamera;
+
+/// Individual camera movement with target position and duration.
+///
+/// Two variants allow different ways to specify the target:
+/// - `ToPosition` — world-space translation + focus (for cinematic sequences)
+/// - `ToOrbit` — orbital parameters around a focus (for zoom-to-fit, avoids gimbal lock)
+#[derive(Clone, Reflect)]
+pub enum CameraMove {
+    /// Animate to a world-space position looking at a focus point.
+    /// The animation system decomposes this into orbital parameters internally.
+    ToPosition {
+        /// World-space camera position.
+        translation: Vec3,
+        /// World-space focus point the camera looks at.
+        focus: Vec3,
+        /// Duration of this movement step.
+        duration: Duration,
+        /// Easing curve for the interpolation.
+        easing: EaseFunction,
+    },
+    /// Animate to orbital parameters around a focus point.
+    /// Avoids gimbal lock at extreme pitch angles (±PI/2) where world-space
+    /// decomposition via `atan2` loses yaw information.
+    ToOrbit {
+        /// World-space focus point the camera orbits around.
+        focus: Vec3,
+        /// Target yaw in radians.
+        yaw: f32,
+        /// Target pitch in radians.
+        pitch: f32,
+        /// Target orbital radius.
+        radius: f32,
+        /// Duration of this movement step.
+        duration: Duration,
+        /// Easing curve for the interpolation.
+        easing: EaseFunction,
+    },
+}
+
+impl CameraMove {
+    /// Returns the duration of this movement step.
+    pub const fn duration(&self) -> Duration {
+        match self {
+            Self::ToPosition { duration, .. } | Self::ToOrbit { duration, .. } => *duration,
+        }
+    }
+
+    /// Returns the duration in milliseconds.
+    pub fn duration_ms(&self) -> f32 {
+        self.duration().as_secs_f32() * 1000.0
+    }
+
+    /// Returns the easing function for this movement step.
+    pub const fn easing(&self) -> EaseFunction {
+        match self {
+            Self::ToPosition { easing, .. } | Self::ToOrbit { easing, .. } => *easing,
+        }
+    }
+
+    /// Returns the focus point for this movement step.
+    pub const fn focus(&self) -> Vec3 {
+        match self {
+            Self::ToPosition { focus, .. } | Self::ToOrbit { focus, .. } => *focus,
+        }
+    }
+
+    /// Returns the world-space camera position for this move.
+    /// For `ToOrbit`, computes the position from orbital parameters.
+    pub fn translation(&self) -> Vec3 {
+        match self {
+            Self::ToPosition { translation, .. } => *translation,
+            Self::ToOrbit {
+                focus,
+                yaw,
+                pitch,
+                radius,
+                ..
+            } => {
+                let yaw_rot = Quat::from_axis_angle(Vec3::Y, *yaw);
+                let pitch_rot = Quat::from_axis_angle(Vec3::X, -*pitch);
+                let rotation = yaw_rot * pitch_rot;
+                *focus + rotation * Vec3::new(0.0, 0.0, *radius)
+            }
+        }
+    }
+
+    /// Returns the target orbital parameters (yaw, pitch, radius).
+    /// For `ToPosition`, decomposes from the world-space offset (may lose yaw at ±PI/2 pitch).
+    fn orbital_params(&self) -> (f32, f32, f32) {
+        match self {
+            Self::ToPosition {
+                translation, focus, ..
+            } => orbital_params_from_offset(*translation - *focus),
+            Self::ToOrbit {
+                yaw, pitch, radius, ..
+            } => (*yaw, *pitch, *radius),
+        }
+    }
+}
+
+/// Decomposes an offset vector (camera position minus focus) into orbital parameters.
+/// Returns `(yaw, pitch, radius)`. May lose yaw information at ±PI/2 pitch due to `atan2`.
+pub(super) fn orbital_params_from_offset(offset: Vec3) -> (f32, f32, f32) {
+    let radius = offset.length();
+    let yaw = offset.x.atan2(offset.z);
+    let horizontal_dist = offset.x.hypot(offset.z);
+    let pitch = offset.y.atan2(horizontal_dist);
+    (yaw, pitch, radius)
+}
+
+/// Tolerance for detecting external camera input during animations.
+/// Values within this threshold are considered unchanged (accounts for floating point noise).
+const EXTERNAL_INPUT_TOLERANCE: f32 = 1e-6;
+
+/// State tracking for the current camera movement
+#[derive(Clone, Reflect, Default, Debug)]
+enum MoveState {
+    InProgress {
+        elapsed_ms: f32,
+        start_focus: Vec3,
+        start_pitch: f32,
+        start_radius: f32,
+        start_yaw: f32,
+        /// Values written by the animation last frame — if the camera's current
+        /// values differ, external input occurred and the animation may interrupt
+        /// depending on `CameraInputInterruptBehavior`.
+        last_written_focus: Vec3,
+        last_written_yaw: f32,
+        last_written_pitch: f32,
+        last_written_radius: f32,
+    },
+    #[default]
+    Ready,
+}
+
+impl MoveState {
+    /// Returns `true` if the camera's orbital parameters have been modified by
+    /// something other than the animation system since the last frame.
+    fn externally_modified(&self, camera: &PanOrbitCamera) -> bool {
+        match self {
+            Self::InProgress {
+                last_written_focus,
+                last_written_yaw,
+                last_written_pitch,
+                last_written_radius,
+                ..
+            } => {
+                let focus_changed =
+                    last_written_focus.distance(camera.target_focus) > EXTERNAL_INPUT_TOLERANCE;
+                let yaw_changed =
+                    (last_written_yaw - camera.target_yaw).abs() > EXTERNAL_INPUT_TOLERANCE;
+                let pitch_changed =
+                    (last_written_pitch - camera.target_pitch).abs() > EXTERNAL_INPUT_TOLERANCE;
+                let radius_changed =
+                    (last_written_radius - camera.target_radius).abs() > EXTERNAL_INPUT_TOLERANCE;
+                focus_changed || yaw_changed || pitch_changed || radius_changed
+            }
+            Self::Ready => false,
+        }
+    }
+}
+
+/// Component that queues multiple camera movements to execute sequentially.
+///
+/// Simply add this component to a camera entity with a list of movements.
+/// The system will automatically process them one by one, removing the component
+/// when the queue is empty.
+///
+/// Camera smoothing is automatically disabled while camera_moves are in progress and
+/// restored when the queue completes via the `restore_camera_state` observer.
+#[derive(Component, Reflect, Default)]
+#[require(CameraInputInterruptBehavior)]
+#[reflect(Component, Default)]
+pub struct CameraMoveList {
+    /// The queue of camera movements to process.
+    pub camera_moves: VecDeque<CameraMove>,
+    state: MoveState,
+}
+
+impl CameraMoveList {
+    /// Creates a new `CameraMoveList` from a queue of movements.
+    pub const fn new(camera_moves: VecDeque<CameraMove>) -> Self {
+        Self {
+            camera_moves,
+            state: MoveState::Ready,
+        }
+    }
+
+    /// Calculates total remaining time in milliseconds for all queued camera_moves.
+    pub fn remaining_time_ms(&self) -> f32 {
+        // Get remaining time for current move
+        let current_remaining = match &self.state {
+            MoveState::InProgress { elapsed_ms, .. } => {
+                if let Some(current_move) = self.camera_moves.front() {
+                    (current_move.duration_ms() - elapsed_ms).max(0.0)
+                } else {
+                    0.0
+                }
+            }
+            MoveState::Ready => self
+                .camera_moves
+                .front()
+                .map_or(0.0, CameraMove::duration_ms),
+        };
+
+        // Add duration of all remaining camera_moves (skip first since already counted)
+        let remaining_queue: f32 = self
+            .camera_moves
+            .iter()
+            .skip(1)
+            .map(CameraMove::duration_ms)
+            .sum();
+
+        current_remaining + remaining_queue
+    }
+}
+
+/// Fires end events when the queue is exhausted and removes animation components.
+fn handle_empty_queue(
+    commands: &mut Commands,
+    entity: Entity,
+    source: AnimationSource,
+    zoom_marker: Option<&ZoomAnimationMarker>,
+) {
+    // Remove components BEFORE triggering events — observers may re-insert
+    // `CameraMoveList` (e.g. splash animation chains hold → zoom → spins),
+    // and a deferred removal after the trigger would wipe the new one.
+    commands
+        .entity(entity)
+        .remove::<(CameraMoveList, AnimationSourceMarker)>();
+    commands.trigger(AnimationEnd {
+        camera: entity,
+        source,
+    });
+    if let Some(marker) = zoom_marker {
+        commands.entity(entity).remove::<ZoomAnimationMarker>();
+        commands.trigger(ZoomEnd {
+            camera: entity,
+            target: marker.0.target,
+            margin: marker.0.margin,
+            duration: marker.0.duration,
+            easing: marker.0.easing,
+        });
+    }
+}
+
+/// Handles external camera input according to `CameraInputInterruptBehavior`.
+/// Returns the concrete handling outcome for this frame.
+#[allow(clippy::too_many_arguments)]
+fn handle_camera_input_interrupt(
+    commands: &mut Commands,
+    entity: Entity,
+    pan_orbit: &mut PanOrbitCamera,
+    queue: &CameraMoveList,
+    interrupt_behavior: &CameraInputInterruptBehavior,
+    source: AnimationSource,
+    current_move: &CameraMove,
+    zoom_marker: Option<&ZoomAnimationMarker>,
+) -> CameraInputInterruptBehavior {
+    match interrupt_behavior {
+        CameraInputInterruptBehavior::Ignore => CameraInputInterruptBehavior::Ignore,
+        CameraInputInterruptBehavior::Cancel => {
+            // Stop where we are — fire cancelled events
+            commands
+                .entity(entity)
+                .remove::<(CameraMoveList, AnimationSourceMarker)>();
+            commands.trigger(AnimationCancelled {
+                camera: entity,
+                source,
+                camera_move: current_move.clone(),
+            });
+            if let Some(marker) = zoom_marker {
+                commands.entity(entity).remove::<ZoomAnimationMarker>();
+                commands.trigger(ZoomCancelled {
+                    camera: entity,
+                    target: marker.0.target,
+                    margin: marker.0.margin,
+                    duration: marker.0.duration,
+                    easing: marker.0.easing,
+                });
+            }
+            CameraInputInterruptBehavior::Cancel
+        }
+        CameraInputInterruptBehavior::Complete => {
+            // Jump to the final position of the entire queue
+            if let Some(final_move) = queue.camera_moves.back() {
+                let (yaw, pitch, radius) = final_move.orbital_params();
+                pan_orbit.target_focus = final_move.focus();
+                pan_orbit.target_yaw = yaw;
+                pan_orbit.target_pitch = pitch;
+                pan_orbit.target_radius = radius;
+                pan_orbit.force_update = true;
+            }
+            // Fire normal end events
+            commands
+                .entity(entity)
+                .remove::<(CameraMoveList, AnimationSourceMarker)>();
+            commands.trigger(AnimationEnd {
+                camera: entity,
+                source,
+            });
+            if let Some(marker) = zoom_marker {
+                commands.entity(entity).remove::<ZoomAnimationMarker>();
+                commands.trigger(ZoomEnd {
+                    camera: entity,
+                    target: marker.0.target,
+                    margin: marker.0.margin,
+                    duration: marker.0.duration,
+                    easing: marker.0.easing,
+                });
+            }
+            CameraInputInterruptBehavior::Complete
+        }
+    }
+}
+
+/// Handles the `Ready` state: zero-duration fast path and transition to `InProgress`.
+/// Returns `true` if the caller should `continue` the outer loop (zero-duration move consumed).
+fn handle_ready_state(
+    commands: &mut Commands,
+    entity: Entity,
+    pan_orbit: &mut PanOrbitCamera,
+    queue: &mut CameraMoveList,
+    current_move: &CameraMove,
+) -> bool {
+    if current_move.duration().is_zero() {
+        commands.trigger(CameraMoveBegin {
+            camera: entity,
+            camera_move: current_move.clone(),
+        });
+
+        let (target_yaw, target_pitch, target_radius) = current_move.orbital_params();
+        pan_orbit.target_focus = current_move.focus();
+        pan_orbit.target_radius = target_radius;
+        pan_orbit.target_yaw = target_yaw;
+        pan_orbit.target_pitch = target_pitch;
+        pan_orbit.force_update = true;
+
+        commands.trigger(CameraMoveEnd {
+            camera: entity,
+            camera_move: current_move.clone(),
+        });
+        queue.camera_moves.pop_front();
+        return true;
+    }
+
+    // Transition to `InProgress` with captured starting orbital parameters
+    queue.state = MoveState::InProgress {
+        elapsed_ms: 0.0,
+        start_focus: pan_orbit.target_focus,
+        start_radius: pan_orbit.target_radius,
+        start_yaw: pan_orbit.target_yaw,
+        start_pitch: pan_orbit.target_pitch,
+        last_written_focus: pan_orbit.target_focus,
+        last_written_yaw: pan_orbit.target_yaw,
+        last_written_pitch: pan_orbit.target_pitch,
+        last_written_radius: pan_orbit.target_radius,
+    };
+
+    commands.trigger(CameraMoveBegin {
+        camera: entity,
+        camera_move: current_move.clone(),
+    });
+
+    false
+}
+
+/// Interpolates the current move, applies easing with angle unwrapping, and advances
+/// the queue when the frame completes.
+fn handle_in_progress(
+    commands: &mut Commands,
+    entity: Entity,
+    pan_orbit: &mut PanOrbitCamera,
+    queue: &mut CameraMoveList,
+    current_move: &CameraMove,
+    delta_secs: f32,
+) {
+    let MoveState::InProgress {
+        elapsed_ms,
+        start_focus,
+        start_radius,
+        start_yaw,
+        start_pitch,
+        last_written_focus,
+        last_written_yaw,
+        last_written_pitch,
+        last_written_radius,
+    } = &mut queue.state
+    else {
+        return;
+    };
+
+    // Update elapsed time
+    *elapsed_ms += delta_secs * 1000.0;
+
+    // Calculate interpolation factor (0.0 to 1.0)
+    let duration_ms = current_move.duration_ms();
+    let t = if duration_ms <= 0.0 {
+        1.0
+    } else {
+        (*elapsed_ms / duration_ms).min(1.0)
+    };
+
+    let is_final_frame = t >= 1.0;
+
+    // Extract target orbital parameters
+    // `ToOrbit` provides them directly; `ToPosition` decomposes via atan2
+    let (canonical_yaw, canonical_pitch, canonical_radius) = current_move.orbital_params();
+
+    // Apply easing function from the move
+    let t_interp = current_move.easing().sample_unchecked(t);
+
+    // Unwrap angles to [-PI, PI] for smooth interpolation (always, including final
+    // frame). Using canonical angles on the final frame causes yaw
+    // snapping when the atan2 decomposition wraps to the opposite side
+    // of the PI boundary.
+    let mut yaw_diff = canonical_yaw - *start_yaw;
+    yaw_diff = std::f32::consts::TAU.mul_add(
+        -((yaw_diff + std::f32::consts::PI) / std::f32::consts::TAU).floor(),
+        yaw_diff,
+    );
+
+    let mut pitch_target = canonical_pitch;
+    let pitch_diff_raw = pitch_target - *start_pitch;
+    if pitch_diff_raw > std::f32::consts::PI {
+        pitch_target -= std::f32::consts::TAU;
+    } else if pitch_diff_raw < -std::f32::consts::PI {
+        pitch_target += std::f32::consts::TAU;
+    }
+    let pitch_diff = pitch_target - *start_pitch;
+
+    // `ToPosition` and `ToOrbit` are both normalized to orbital params above
+    pan_orbit.target_focus = start_focus.lerp(current_move.focus(), t_interp);
+    pan_orbit.target_radius = (canonical_radius - *start_radius).mul_add(t_interp, *start_radius);
+    pan_orbit.target_yaw = yaw_diff.mul_add(t_interp, *start_yaw);
+    pan_orbit.target_pitch = pitch_diff.mul_add(t_interp, *start_pitch);
+    pan_orbit.force_update = true;
+
+    // Save what we wrote so we can detect external changes next frame
+    *last_written_focus = pan_orbit.target_focus;
+    *last_written_yaw = pan_orbit.target_yaw;
+    *last_written_pitch = pan_orbit.target_pitch;
+    *last_written_radius = pan_orbit.target_radius;
+
+    // Check if move complete and advance to next
+    if is_final_frame {
+        commands.trigger(CameraMoveEnd {
+            camera: entity,
+            camera_move: current_move.clone(),
+        });
+        queue.camera_moves.pop_front();
+        queue.state = MoveState::Ready;
+    }
+}
+
+/// System that processes camera movement queues with duration-based interpolation.
+///
+/// When a `PanOrbitCamera` has a `CameraMoveList`, interpolates toward the target over
+/// the specified duration with easing. When a move completes, automatically moves to the
+/// next. Removes the `CameraMoveList` component when all moves are complete.
+#[allow(clippy::type_complexity)]
+pub(super) fn process_camera_move_list(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut camera_query: Query<(
+        Entity,
+        &mut PanOrbitCamera,
+        &mut CameraMoveList,
+        &CameraInputInterruptBehavior,
+        Option<&ZoomAnimationMarker>,
+        Option<&AnimationSourceMarker>,
+    )>,
+) {
+    for (entity, mut pan_orbit, mut queue, interrupt_behavior, zoom_marker, source_marker) in
+        &mut camera_query
+    {
+        let source = source_marker.map_or(AnimationSource::PlayAnimation, |m| m.0);
+
+        let Some(current_move) = queue.camera_moves.front().cloned() else {
+            handle_empty_queue(&mut commands, entity, source, zoom_marker);
+            continue;
+        };
+
+        if queue.state.externally_modified(&pan_orbit) {
+            let outcome = handle_camera_input_interrupt(
+                &mut commands,
+                entity,
+                &mut pan_orbit,
+                &queue,
+                interrupt_behavior,
+                source,
+                &current_move,
+                zoom_marker,
+            );
+            match outcome {
+                CameraInputInterruptBehavior::Ignore => {}
+                CameraInputInterruptBehavior::Cancel | CameraInputInterruptBehavior::Complete => {
+                    continue;
+                }
+            }
+        }
+
+        match &queue.state {
+            MoveState::Ready => {
+                if handle_ready_state(
+                    &mut commands,
+                    entity,
+                    &mut pan_orbit,
+                    &mut queue,
+                    &current_move,
+                ) {
+                    continue;
+                }
+            }
+            MoveState::InProgress { .. } => {
+                handle_in_progress(
+                    &mut commands,
+                    entity,
+                    &mut pan_orbit,
+                    &mut queue,
+                    &current_move,
+                    time.delta_secs(),
+                );
+            }
+        }
+    }
+}

--- a/src/extras/components.rs
+++ b/src/extras/components.rs
@@ -1,0 +1,104 @@
+//! Components used by the camera extension system.
+
+use bevy::prelude::*;
+
+use super::events::AnimationSource;
+use super::events::ZoomContext;
+
+/// Controls what happens when **user input to the camera** (orbit, pan, zoom) occurs during an
+/// in-flight animation.
+///
+/// This is a required component on [`CameraMoveList`](crate::CameraMoveList) — if not
+/// explicitly inserted, it defaults to [`Ignore`](CameraInputInterruptBehavior::Ignore).
+///
+/// This component is orthogonal to [`AnimationConflictPolicy`] — `CameraInputInterruptBehavior`
+/// handles physical camera input during an animation, while `AnimationConflictPolicy`
+/// handles programmatic animation requests that arrive while one is already playing.
+///
+/// - [`Ignore`](CameraInputInterruptBehavior::Ignore) — disable camera input while animating and
+///   keep animating uninterrupted. No interrupt lifecycle events are emitted.
+/// - [`Cancel`](CameraInputInterruptBehavior::Cancel) — stop the camera where it is and fire
+///   `*Cancelled` events
+/// - [`Complete`](CameraInputInterruptBehavior::Complete) — jump to the final position of the
+///   entire queue and fire normal `*End` events
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub enum CameraInputInterruptBehavior {
+    /// Disable camera input and keep animating uninterrupted.
+    #[default]
+    Ignore,
+    /// Stop the camera at its current position. Fires `AnimationCancelled` or `ZoomCancelled`.
+    Cancel,
+    /// Jump to the final queued position. Fires `AnimationEnd` or `ZoomEnd`.
+    Complete,
+}
+
+/// Controls what happens when a **new animation request** arrives while one is already
+/// in-flight.
+///
+/// Insert this component on a camera entity to configure conflict resolution. If not
+/// present, defaults to [`LastWins`](AnimationConflictPolicy::LastWins).
+///
+/// This component is orthogonal to [`CameraInputInterruptBehavior`] — `AnimationConflictPolicy`
+/// handles programmatic animation requests (e.g. [`ZoomToFit`](crate::ZoomToFit),
+/// [`PlayAnimation`](crate::PlayAnimation)) that conflict with an active animation, while
+/// `CameraInputInterruptBehavior` handles physical user input interrupting an animation.
+///
+/// - [`LastWins`](AnimationConflictPolicy::LastWins) — cancel the current animation and start the
+///   new one. Fires appropriate `*Cancelled` events for the interrupted operation.
+/// - [`FirstWins`](AnimationConflictPolicy::FirstWins) — reject the incoming request. Fires
+///   [`AnimationRejected`](crate::AnimationRejected).
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub enum AnimationConflictPolicy {
+    /// Cancel the current animation and start the new one.
+    #[default]
+    LastWins,
+    /// Reject the incoming request and keep the current animation.
+    FirstWins,
+}
+
+/// Marks the entity that the camera is currently fitted to.
+/// Persists after fit completes to enable persistent visualization.
+#[derive(Component, Reflect, Debug)]
+#[reflect(Component)]
+pub struct CurrentFitTarget(
+    /// The entity being fitted.
+    pub Entity,
+);
+
+/// Marker component that tracks a zoom-to-fit operation routed through the animation system.
+/// When `AnimationEnd` fires on an entity with this marker, `ZoomEnd` is triggered and the
+/// marker is removed. Wraps the [`ZoomContext`] that originated the zoom.
+#[derive(Component, Clone)]
+pub(super) struct ZoomAnimationMarker(pub ZoomContext);
+
+/// Marker component that tracks whether an animation was triggered by
+/// [`PlayAnimation`](crate::PlayAnimation), [`ZoomToFit`](crate::ZoomToFit), or
+/// [`AnimateToFit`](crate::AnimateToFit). Inserted alongside
+/// [`CameraMoveList`](crate::CameraMoveList) and removed when the animation ends or is cancelled.
+#[derive(Component)]
+pub(super) struct AnimationSourceMarker(pub AnimationSource);
+
+/// Component that stores camera runtime state values during animations.
+///
+/// When camera animations are active (via `CameraMoveList`), the smoothness values are
+/// temporarily set to 0.0 for instant movement. Depending on
+/// [`CameraInputInterruptBehavior`], camera input may also be temporarily disabled.
+/// Original values are stored here and restored when the animation completes.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub(super) struct PanOrbitCameraStash {
+    pub zoom: f32,
+    pub pan: f32,
+    pub orbit: f32,
+    pub enabled: bool,
+}
+
+/// Enables fit target debug visualization on a camera entity.
+///
+/// Insert this component to enable visualization, remove it to disable.
+/// The presence or absence of the component is the toggle — no boolean field needed.
+#[cfg(feature = "extras_debug")]
+#[derive(Component, Reflect, Default)]
+#[reflect(Component, Default)]
+pub struct FitVisualization;

--- a/src/extras/events.rs
+++ b/src/extras/events.rs
@@ -1,0 +1,632 @@
+//! Events for camera animations and zoom operations.
+//!
+//! Events are organized by feature. Each group starts with the **trigger** event
+//! (fire with `commands.trigger(...)`) followed by the **fired** events it produces
+//! (observe with `.add_observer(...)`).
+//!
+//! # Common patterns
+//!
+//! **Duration** — several events accept a `duration` field. When set to
+//! `Duration::ZERO` the operation completes instantly — the camera snaps to its
+//! final position and only the **operation-level** begin/end events fire (see
+//! [instant paths](#instant-operations) below). When `duration > Duration::ZERO`
+//! the operation animates over time through [`PlayAnimation`], so the full nested
+//! event sequence fires.
+//!
+//! **Easing** — events that animate also accept an `easing` field
+//! ([`EaseFunction`]) that controls the interpolation curve. This only has an effect
+//! when `duration > Duration::ZERO`.
+//!
+//! # Event ordering
+//!
+//! Events nest from outermost (operation-level) to innermost (move-level). Every
+//! animated path goes through [`PlayAnimation`], so [`AnimationBegin`]/[`AnimationEnd`]
+//! and [`CameraMoveBegin`]/[`CameraMoveEnd`] fire for **all** animated operations —
+//! including [`ZoomToFit`] and [`AnimateToFit`].
+//!
+//! ## `PlayAnimation` — normal completion
+//!
+//! ```text
+//! AnimationBegin → CameraMoveBegin → CameraMoveEnd → … → AnimationEnd
+//! ```
+//!
+//! ## `ZoomToFit` (animated) — normal completion
+//!
+//! `Zoom*` events wrap the animation lifecycle:
+//!
+//! ```text
+//! ZoomBegin → AnimationBegin → CameraMoveBegin → CameraMoveEnd → AnimationEnd → ZoomEnd
+//! ```
+//!
+//! ## `AnimateToFit` (animated) — normal completion
+//!
+//! No extra wrapping events — uses `source: AnimationSource::AnimateToFit` to
+//! distinguish from a plain [`PlayAnimation`]:
+//!
+//! ```text
+//! AnimationBegin → CameraMoveBegin → CameraMoveEnd → AnimationEnd
+//! ```
+//!
+//! ## Instant operations
+//!
+//! When `duration` is `Duration::ZERO`, the animation system is bypassed entirely.
+//! Only the operation-level events fire — no [`AnimationBegin`]/[`AnimationEnd`] or
+//! [`CameraMoveBegin`]/[`CameraMoveEnd`].
+//!
+//! ### `ZoomToFit` (instant)
+//!
+//! ```text
+//! ZoomBegin → ZoomEnd
+//! ```
+//!
+//! ### `AnimateToFit` (instant)
+//!
+//! Fires animation-level events (to notify observers) but no camera-move-level events:
+//!
+//! ```text
+//! AnimationBegin → AnimationEnd
+//! ```
+//!
+//! ## User input interruption ([`CameraInputInterruptBehavior`](crate::CameraInputInterruptBehavior))
+//!
+//! When the user physically moves the camera during an animation:
+//!
+//! - **`Ignore`** (default) — temporarily disables camera input and continues animating:
+//!
+//!   ```text
+//!   … (no interrupt lifecycle event)
+//!   ```
+//!
+//! - **`Cancel`** — stops where it is:
+//!
+//!   ```text
+//!   … → AnimationCancelled → ZoomCancelled (if zoom)
+//!   ```
+//!
+//! - **`Complete`** — jumps to the final position:
+//!
+//!   ```text
+//!   … → AnimationEnd → ZoomEnd (if zoom)
+//!   ```
+//!
+//! ## Animation conflict ([`AnimationConflictPolicy`](crate::AnimationConflictPolicy))
+//!
+//! When a new animation request arrives while one is already in-flight:
+//!
+//! - **`LastWins`** (default) — cancels the in-flight animation, then starts the new one.
+//!   `AnimationCancelled` always fires; `ZoomCancelled` additionally fires if the in-flight
+//!   operation is a zoom:
+//!
+//!   ```text
+//!   AnimationCancelled → ZoomCancelled (if zoom) → AnimationBegin (new) → …
+//!   ```
+//!
+//! - **`FirstWins`** — rejects the incoming request. No zoom lifecycle events fire — the rejection
+//!   is detected before `ZoomBegin`:
+//!
+//!   ```text
+//!   AnimationRejected
+//!   ```
+//!
+//!   The [`AnimationRejected::source`] field identifies what was rejected
+//!   ([`AnimationSource::PlayAnimation`], [`AnimationSource::ZoomToFit`], or
+//!   [`AnimationSource::AnimateToFit`]).
+//!
+//! # Emitted event data
+//!
+//! Reference of data carried by events — for comparison purposes.
+//!
+//! | Event                    | `camera` | `target` | `margin` | `duration` | `easing` | `source` | `camera_move` |
+//! |--------------------------|-----------------|-----------------|----------|------------|----------|----------|---------------|
+//! | [`ZoomBegin`]            | yes             | yes             | yes      | yes        | yes      | —        | —             |
+//! | [`ZoomEnd`]              | yes             | yes             | yes      | yes        | yes      | —        | —             |
+//! | [`ZoomCancelled`]        | yes             | yes             | yes      | yes        | yes      | —        | —             |
+//! | [`AnimationBegin`]       | yes             | —               | —        | —          | —        | yes      | —             |
+//! | [`AnimationEnd`]         | yes             | —               | —        | —          | —        | yes      | —             |
+//! | [`AnimationCancelled`]   | yes             | —               | —        | —          | —        | yes      | yes           |
+//! | [`AnimationRejected`]    | yes             | —               | —        | —          | —        | yes      | —             |
+//! | [`CameraMoveBegin`]      | yes             | —               | —        | —          | —        | —        | yes           |
+//! | [`CameraMoveEnd`]        | yes             | —               | —        | —          | —        | —        | yes           |
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use bevy::math::curve::easing::EaseFunction;
+use bevy::prelude::*;
+
+use super::animation::CameraMove;
+
+/// Context for a zoom-to-fit operation, passed through [`PlayAnimation`] so
+/// that `on_play_animation` can fire [`ZoomBegin`] and insert
+/// [`ZoomAnimationMarker`](super::components::ZoomAnimationMarker) at the
+/// single point where conflict resolution has already completed.
+#[derive(Clone, Reflect)]
+pub struct ZoomContext {
+    /// The entity being framed.
+    pub target: Entity,
+    /// The margin from the triggering [`ZoomToFit`].
+    pub margin: f32,
+    /// The duration from the triggering [`ZoomToFit`].
+    pub duration: Duration,
+    /// The easing curve from the triggering [`ZoomToFit`].
+    pub easing: EaseFunction,
+}
+
+/// Identifies which event triggered an animation lifecycle.
+///
+/// Carried by [`AnimationBegin`], [`AnimationEnd`], [`AnimationCancelled`], and
+/// [`AnimationRejected`] so observers know whether the animation originated from
+/// [`PlayAnimation`], [`ZoomToFit`], or [`AnimateToFit`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Reflect)]
+pub enum AnimationSource {
+    /// Animation was triggered by [`PlayAnimation`].
+    PlayAnimation,
+    /// Animation was triggered by [`ZoomToFit`].
+    ZoomToFit,
+    /// Animation was triggered by [`AnimateToFit`].
+    AnimateToFit,
+    /// Animation was triggered by [`LookAt`].
+    LookAt,
+    /// Animation was triggered by [`LookAtAndZoomToFit`].
+    LookAtAndZoomToFit,
+}
+
+/// `ZoomToFit` — frames a target entity in the camera view without changing the
+/// camera's viewing angle.
+///
+/// The camera's yaw and pitch stay fixed. Only the focus and radius change so
+/// that the target fills the viewport with the requested margin. Because the
+/// viewing angle is preserved, the camera *translates* to a new position rather
+/// than rotating — if the target is off to the side, the view slides over to it.
+///
+/// # See also
+///
+/// - [`LookAt`] — keeps the camera in place and *rotates* to face the target (no framing / radius
+///   adjustment).
+/// - [`LookAtAndZoomToFit`] — *rotates* to face the target and adjusts radius to frame it. Use this
+///   when you want the camera to turn toward the target instead of sliding.
+/// - [`AnimateToFit`] — frames the target from a caller-specified viewing angle.
+///
+/// # Fields
+///
+/// - `camera` — the entity with a `PanOrbitCamera` component.
+/// - `target` — the entity to frame; must have a `Mesh3d` (direct or on descendants).
+/// - `margin` — total fraction of the screen to leave as space between the target's screen-space
+///   bounding box and the screen edge, split equally across both sides of the constraining
+///   dimension (e.g. `0.25` → ~12.5% each side).
+/// - `duration` — see module-level docs on **Duration**.
+/// - `easing` — see module-level docs on **Easing**.
+///
+/// Animated zooms route through [`PlayAnimation`], so the full event sequence is
+/// `ZoomBegin` → `AnimationBegin` → `CameraMoveBegin` → `CameraMoveEnd` →
+/// `AnimationEnd` → `ZoomEnd`. See the [module-level event ordering](self#event-ordering)
+/// docs for interruption and conflict scenarios.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct ZoomToFit {
+    /// The camera entity to zoom.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity to frame.
+    pub target: Entity,
+    /// Fraction of screen to leave as margin.
+    pub margin: f32,
+    /// Animation duration (`ZERO` for instant).
+    pub duration: Duration,
+    /// Easing curve for the animation.
+    pub easing: EaseFunction,
+}
+
+impl ZoomToFit {
+    /// Creates a new `ZoomToFit` event with default margin, instant duration, and cubic-out easing.
+    pub const fn new(camera: Entity, target: Entity) -> Self {
+        Self {
+            camera,
+            target,
+            margin: 0.1,
+            duration: Duration::ZERO,
+            easing: EaseFunction::CubicOut,
+        }
+    }
+
+    /// Sets the margin.
+    pub const fn margin(mut self, margin: f32) -> Self {
+        self.margin = margin;
+        self
+    }
+
+    /// Sets the animation duration.
+    pub const fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Sets the easing function.
+    pub const fn easing(mut self, easing: EaseFunction) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+/// `ZoomBegin` — emitted when a [`ZoomToFit`] operation begins.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct ZoomBegin {
+    /// The camera that is zooming.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity being framed.
+    pub target: Entity,
+    /// The margin from the triggering [`ZoomToFit`].
+    pub margin: f32,
+    /// The duration from the triggering [`ZoomToFit`].
+    pub duration: Duration,
+    /// The easing curve from the triggering [`ZoomToFit`].
+    pub easing: EaseFunction,
+}
+
+/// `ZoomEnd` — emitted when a [`ZoomToFit`] operation completes (both animated and instant).
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct ZoomEnd {
+    /// The camera that finished zooming.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity that was framed.
+    pub target: Entity,
+    /// The margin from the triggering [`ZoomToFit`].
+    pub margin: f32,
+    /// The duration from the triggering [`ZoomToFit`].
+    pub duration: Duration,
+    /// The easing curve from the triggering [`ZoomToFit`].
+    pub easing: EaseFunction,
+}
+
+/// `ZoomCancelled` — emitted when a [`ZoomToFit`] animation is cancelled before completion.
+/// The camera stays at its current position — no snap to final.
+///
+/// Cancellation happens in two scenarios:
+/// - **User input** — the user physically moves the camera while
+///   [`CameraInputInterruptBehavior::Cancel`](crate::CameraInputInterruptBehavior::Cancel) is
+///   active.
+/// - **Animation conflict** — a new animation request arrives while
+///   [`AnimationConflictPolicy::LastWins`](crate::AnimationConflictPolicy::LastWins) is active,
+///   cancelling the in-flight zoom.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct ZoomCancelled {
+    /// The camera whose zoom was cancelled.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity that was being framed.
+    pub target: Entity,
+    /// The margin from the triggering [`ZoomToFit`].
+    pub margin: f32,
+    /// The duration from the triggering [`ZoomToFit`].
+    pub duration: Duration,
+    /// The easing curve from the triggering [`ZoomToFit`].
+    pub easing: EaseFunction,
+}
+
+/// `PlayAnimation` — plays a queued sequence of [`CameraMove`] steps.
+///
+/// Fires `AnimationBegin` → (`CameraMoveBegin` → `CameraMoveEnd`) × N → `AnimationEnd`.
+/// See the [module-level event ordering](self#event-ordering) docs for interruption and
+/// conflict scenarios.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct PlayAnimation {
+    /// The camera entity to animate.
+    #[event_target]
+    pub camera: Entity,
+    /// The queue of camera movements.
+    pub camera_moves: VecDeque<CameraMove>,
+    /// The source of this animation.
+    pub source: AnimationSource,
+    /// Optional zoom context when this animation originates from [`ZoomToFit`].
+    pub zoom_context: Option<ZoomContext>,
+}
+
+impl PlayAnimation {
+    /// Creates a new `PlayAnimation` event.
+    pub fn new(camera: Entity, camera_moves: impl IntoIterator<Item = CameraMove>) -> Self {
+        Self {
+            camera,
+            camera_moves: camera_moves.into_iter().collect(),
+            source: AnimationSource::PlayAnimation,
+            zoom_context: None,
+        }
+    }
+
+    /// Sets the animation source.
+    pub fn source(mut self, source: AnimationSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Sets the zoom context (implies `AnimationSource::ZoomToFit`).
+    pub fn zoom_context(mut self, ctx: ZoomContext) -> Self {
+        self.zoom_context = Some(ctx);
+        self.source = AnimationSource::ZoomToFit;
+        self
+    }
+}
+
+/// `AnimationBegin` — emitted when a `CameraMoveList` begins processing.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct AnimationBegin {
+    /// The camera being animated.
+    #[event_target]
+    pub camera: Entity,
+    /// Whether this animation originated from [`PlayAnimation`], [`ZoomToFit`], or
+    /// [`AnimateToFit`].
+    pub source: AnimationSource,
+}
+
+/// `AnimationEnd` — emitted when a `CameraMoveList` finishes all its queued moves.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct AnimationEnd {
+    /// The camera that finished animating.
+    #[event_target]
+    pub camera: Entity,
+    /// Whether this animation originated from [`PlayAnimation`], [`ZoomToFit`], or
+    /// [`AnimateToFit`].
+    pub source: AnimationSource,
+}
+
+/// `AnimationCancelled` — emitted when a [`PlayAnimation`], [`ZoomToFit`], or [`AnimateToFit`] is
+/// cancelled before completion. The camera stays at its current position — no snap to final.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct AnimationCancelled {
+    /// The camera whose animation was cancelled.
+    #[event_target]
+    pub camera: Entity,
+    /// Whether this animation originated from [`PlayAnimation`], [`ZoomToFit`], or
+    /// [`AnimateToFit`].
+    pub source: AnimationSource,
+    /// The [`CameraMove`] that was in progress when cancelled.
+    pub camera_move: CameraMove,
+}
+
+/// `AnimationRejected` — emitted when an incoming animation request is rejected because
+/// [`AnimationConflictPolicy::FirstWins`](crate::AnimationConflictPolicy::FirstWins) is
+/// active and an animation is already in-flight.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct AnimationRejected {
+    /// The camera that rejected the animation.
+    #[event_target]
+    pub camera: Entity,
+    /// The [`AnimationSource`] of the rejected request.
+    pub source: AnimationSource,
+}
+
+/// `CameraMoveBegin` — emitted when an individual [`CameraMove`] begins.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct CameraMoveBegin {
+    /// The camera being animated.
+    #[event_target]
+    pub camera: Entity,
+    /// The [`CameraMove`] step that is starting.
+    pub camera_move: CameraMove,
+}
+
+/// `CameraMoveEnd` — emitted when an individual [`CameraMove`] completes.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct CameraMoveEnd {
+    /// The camera that finished this move step.
+    #[event_target]
+    pub camera: Entity,
+    /// The [`CameraMove`] step that completed.
+    pub camera_move: CameraMove,
+}
+
+/// `AnimateToFit` — animates the camera to a caller-specified orientation while
+/// framing a target entity in view.
+///
+/// You specify the exact yaw and pitch the camera should end up at, and the
+/// system computes the radius needed to frame the target from that angle.
+///
+/// # See also
+///
+/// - [`LookAtAndZoomToFit`] — like `AnimateToFit` but the yaw/pitch are automatically back-solved
+///   from the camera's current position, so you don't specify them.
+/// - [`ZoomToFit`] — keeps the current viewing angle, only adjusts focus and radius.
+/// - [`LookAt`] — rotates to face the target without framing.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct AnimateToFit {
+    /// The camera entity.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity to frame.
+    pub target: Entity,
+    /// Final yaw in radians.
+    pub yaw: f32,
+    /// Final pitch in radians.
+    pub pitch: f32,
+    /// Fraction of screen to leave as margin.
+    pub margin: f32,
+    /// Animation duration (`ZERO` for instant).
+    pub duration: Duration,
+    /// Easing curve for the animation.
+    pub easing: EaseFunction,
+}
+
+impl AnimateToFit {
+    /// Creates a new `AnimateToFit` with default parameters.
+    pub const fn new(camera: Entity, target: Entity) -> Self {
+        Self {
+            camera,
+            target,
+            yaw: 0.0,
+            pitch: 0.0,
+            margin: 0.1,
+            duration: Duration::ZERO,
+            easing: EaseFunction::CubicOut,
+        }
+    }
+
+    /// Sets the target yaw.
+    pub const fn yaw(mut self, yaw: f32) -> Self {
+        self.yaw = yaw;
+        self
+    }
+
+    /// Sets the target pitch.
+    pub const fn pitch(mut self, pitch: f32) -> Self {
+        self.pitch = pitch;
+        self
+    }
+
+    /// Sets the margin.
+    pub const fn margin(mut self, margin: f32) -> Self {
+        self.margin = margin;
+        self
+    }
+
+    /// Sets the animation duration.
+    pub const fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Sets the easing function.
+    pub const fn easing(mut self, easing: EaseFunction) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+/// `LookAt` — rotates the camera in place to face a target entity.
+///
+/// The camera stays at its current world position and turns to look at the target.
+/// The orbit pivot re-anchors to the target entity's [`GlobalTransform`] translation,
+/// and yaw/pitch/radius are back-solved so the camera does not move — only its
+/// orientation changes.
+///
+/// # See also
+///
+/// - [`LookAtAndZoomToFit`] — same rotation, but also adjusts radius to frame the target in view.
+/// - [`ZoomToFit`] — keeps the viewing angle, moves the camera to frame the target.
+/// - [`AnimateToFit`] — frames the target from a caller-specified viewing angle.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct LookAt {
+    /// The camera entity.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity to look at.
+    pub target: Entity,
+    /// Animation duration (`ZERO` for instant).
+    pub duration: Duration,
+    /// Easing curve for the animation.
+    pub easing: EaseFunction,
+}
+
+impl LookAt {
+    /// Creates a new `LookAt` with instant duration and cubic-out easing.
+    pub const fn new(camera: Entity, target: Entity) -> Self {
+        Self {
+            camera,
+            target,
+            duration: Duration::ZERO,
+            easing: EaseFunction::CubicOut,
+        }
+    }
+
+    /// Sets the animation duration.
+    pub const fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Sets the easing function.
+    pub const fn easing(mut self, easing: EaseFunction) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+/// `LookAtAndZoomToFit` — rotates the camera to face a target entity and adjusts
+/// the radius to frame it in view, all in one fluid motion.
+///
+/// Combines [`LookAt`] (turn in place) with [`ZoomToFit`] (frame the target).
+/// The yaw and pitch are back-solved from the camera's current world position
+/// relative to the target's bounds center — you don't specify them.
+///
+/// # See also
+///
+/// - [`LookAt`] — same rotation without the zoom-to-fit radius adjustment.
+/// - [`ZoomToFit`] — keeps the viewing angle, moves the camera to frame the target.
+/// - [`AnimateToFit`] — frames the target from a caller-specified viewing angle.
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct LookAtAndZoomToFit {
+    /// The camera entity.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity to frame.
+    pub target: Entity,
+    /// Fraction of screen to leave as margin.
+    pub margin: f32,
+    /// Animation duration (`ZERO` for instant).
+    pub duration: Duration,
+    /// Easing curve for the animation.
+    pub easing: EaseFunction,
+}
+
+impl LookAtAndZoomToFit {
+    /// Creates a new `LookAtAndZoomToFit` with default parameters.
+    pub const fn new(camera: Entity, target: Entity) -> Self {
+        Self {
+            camera,
+            target,
+            margin: 0.1,
+            duration: Duration::ZERO,
+            easing: EaseFunction::CubicOut,
+        }
+    }
+
+    /// Sets the margin.
+    pub const fn margin(mut self, margin: f32) -> Self {
+        self.margin = margin;
+        self
+    }
+
+    /// Sets the animation duration.
+    pub const fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Sets the easing function.
+    pub const fn easing(mut self, easing: EaseFunction) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+/// `SetFitTarget` — sets the visualization target without triggering a zoom. Allows you
+/// to inspect bounds before triggering [`ZoomToFit`].
+#[derive(EntityEvent, Reflect)]
+#[reflect(Event, FromReflect)]
+pub struct SetFitTarget {
+    /// The camera entity.
+    #[event_target]
+    pub camera: Entity,
+    /// The entity whose bounds to visualize.
+    pub target: Entity,
+}
+
+impl SetFitTarget {
+    /// Creates a new `SetFitTarget` event.
+    pub const fn new(camera: Entity, target: Entity) -> Self {
+        Self { camera, target }
+    }
+}

--- a/src/extras/events.rs
+++ b/src/extras/events.rs
@@ -612,8 +612,14 @@ impl LookAtAndZoomToFit {
     }
 }
 
-/// `SetFitTarget` — sets the visualization target without triggering a zoom. Allows you
-/// to inspect bounds before triggering [`ZoomToFit`].
+/// Sets the debug visualization target without triggering a zoom.
+///
+/// Only useful with the `extras_debug` feature enabled. This lets you point the
+/// debug overlay (`FitVisualization`) at a specific entity so you can inspect its
+/// screen-space bounds before (or without) triggering [`ZoomToFit`].
+///
+/// You do not need to call this when using [`ZoomToFit`], [`AnimateToFit`], or
+/// [`LookAtAndZoomToFit`] — those events set the fit target automatically.
 #[derive(EntityEvent, Reflect)]
 #[reflect(Event, FromReflect)]
 pub struct SetFitTarget {

--- a/src/extras/fit.rs
+++ b/src/extras/fit.rs
@@ -319,7 +319,7 @@ fn build_test_projection(projection: &Projection, test_radius: f32) -> Projectio
 /// For perspective, each correction step uses the harmonic mean of the depths of the two
 /// extreme points per dimension. This is the exact inverse of perspective projection.
 ///
-/// For orthographic, centering is depth-independent (centering_depth = 1.0), so the shift
+/// For orthographic, centering is depth-independent (`centering_depth` = 1.0), so the shift
 /// is a direct 1:1 world-unit correction.
 #[allow(clippy::too_many_arguments)]
 fn refine_focus_centering(

--- a/src/extras/fit.rs
+++ b/src/extras/fit.rs
@@ -1,0 +1,454 @@
+//! Fit algorithm for framing objects in the camera view.
+//!
+//! Provides screen-space projection, margin calculation, and a binary search convergence
+//! loop that finds the optimal camera radius and focus to frame a set of mesh vertices
+//! with a specified margin.
+
+use core::fmt;
+
+use bevy::prelude::*;
+
+use super::support::projection_aspect_ratio;
+use super::support::ScreenSpaceBounds;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Maximum binary search iterations.
+pub const MAX_ITERATIONS: usize = 200;
+/// Convergence tolerance (0.1% of search range).
+pub const TOLERANCE: f32 = 0.001;
+/// Maximum centering iterations per candidate radius.
+pub const CENTERING_MAX_ITERATIONS: usize = 10;
+/// Normalized screen-space center offset tolerance.
+pub const CENTERING_TOLERANCE: f32 = 0.0001;
+/// Minimum allowed margin value.
+pub const MIN_MARGIN: f32 = 0.0;
+/// Maximum allowed margin value.
+pub const MAX_MARGIN: f32 = 0.9999;
+/// Minimum search radius as a fraction of the object radius (0.1x).
+pub const MIN_RADIUS_MULTIPLIER: f32 = 0.1;
+/// Maximum search radius as a multiple of the object radius (100x).
+pub const MAX_RADIUS_MULTIPLIER: f32 = 100.0;
+/// Initial best-guess radius as a multiple of the object radius (2x).
+pub const INITIAL_RADIUS_MULTIPLIER: f32 = 2.0;
+
+/// Returns the zoom margin multiplier (1.0 / (1.0 - margin)).
+/// For example, a margin of 0.08 returns 1.087 (8% margin).
+pub const fn zoom_margin_multiplier(margin: f32) -> f32 {
+    1.0 / (1.0 - margin)
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Screen edge identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+pub enum Edge {
+    /// Left screen edge.
+    Left,
+    /// Right screen edge.
+    Right,
+    /// Top screen edge.
+    Top,
+    /// Bottom screen edge.
+    Bottom,
+}
+
+/// Successful fit output: camera orbit radius and centered focus point.
+#[derive(Debug, Clone, Copy)]
+pub struct FitSolution {
+    /// The optimal orbital radius.
+    pub radius: f32,
+    /// The centered focus point.
+    pub focus: Vec3,
+}
+
+/// Explicit fit calculation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FitError {
+    /// Camera viewport size/aspect ratio is unavailable.
+    NoViewport,
+    /// All candidate fits projected points behind the camera.
+    PointsBehindCamera,
+}
+
+impl fmt::Display for FitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoViewport => write!(f, "camera viewport size is unavailable"),
+            Self::PointsBehindCamera => {
+                write!(f, "all candidate fits project points behind camera")
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Target margin calculation
+// ============================================================================
+
+/// Computes the target margins for the constraining dimension based on aspect ratios.
+/// Returns `(target_margin_x, target_margin_y)`.
+fn calculate_target_margins(bounds: &ScreenSpaceBounds, zoom_multiplier: f32) -> (f32, f32) {
+    let boundary_aspect =
+        (bounds.max_norm_x - bounds.min_norm_x) / (bounds.max_norm_y - bounds.min_norm_y);
+    let screen_aspect = bounds.half_extent_x / bounds.half_extent_y;
+
+    // If boundary is wider (relative to height) than screen, width constrains
+    let width_constrains = boundary_aspect > screen_aspect;
+
+    let (target_edge_x, target_edge_y) = if width_constrains {
+        let target_x = bounds.half_extent_x / zoom_multiplier;
+        let target_y = target_x / boundary_aspect;
+        (target_x, target_y)
+    } else {
+        let target_y = bounds.half_extent_y / zoom_multiplier;
+        let target_x = target_y * boundary_aspect;
+        (target_x, target_y)
+    };
+
+    (
+        bounds.half_extent_x - target_edge_x,
+        bounds.half_extent_y - target_edge_y,
+    )
+}
+
+// ============================================================================
+// Convergence algorithm
+// ============================================================================
+
+/// Calculates the optimal radius and centered focus to fit pre-extracted vertices in the camera
+/// view. The focus is adjusted so the projected mesh silhouette is centered in the viewport.
+///
+/// For each candidate radius, computes the focus that centers the projected silhouette in the
+/// viewport (since the geometric center doesn't project to screen center from off-axis angles),
+/// then evaluates margins at that centered position. Returns the fit solution where
+/// the constraining margin equals the target and the silhouette is centered.
+///
+/// Note: A lateral camera shift doesn't change point depths, so the centering is geometrically
+/// exact for the constraining margin check.
+pub fn calculate_fit(
+    points: &[Vec3],
+    geometric_center: Vec3,
+    yaw: f32,
+    pitch: f32,
+    margin: f32,
+    projection: &Projection,
+    camera: &Camera,
+) -> Result<FitSolution, FitError> {
+    let clamped_margin = if margin.is_nan() {
+        MIN_MARGIN
+    } else {
+        margin.clamp(MIN_MARGIN, MAX_MARGIN)
+    };
+    if clamped_margin != margin {
+        warn!(
+            "calculate_fit: clamped margin from {margin} to {clamped_margin} (expected [{MIN_MARGIN}, {MAX_MARGIN}])"
+        );
+    }
+
+    let aspect_ratio = projection_aspect_ratio(projection, camera.logical_viewport_size())
+        .ok_or(FitError::NoViewport)?;
+
+    // For ortho, the camera is always at a fixed distance from focus.
+    // PanOrbitCamera sets this to `(near + far) / 2.0`.
+    let ortho_fixed_distance = match projection {
+        Projection::Orthographic(o) => Some((o.near + o.far) * 0.5),
+        _ => None,
+    };
+
+    let is_ortho = ortho_fixed_distance.is_some();
+    let zoom_multiplier = zoom_margin_multiplier(clamped_margin);
+
+    let rot = Quat::from_euler(EulerRot::YXZ, yaw, -pitch, 0.0);
+
+    // Compute the object's bounding sphere radius from points for sensible search bounds.
+    // The search range is based purely on object size to ensure deterministic results
+    // regardless of the camera's current radius.
+    let object_radius = points
+        .iter()
+        .map(|c| (*c - geometric_center).length())
+        .fold(0.0_f32, f32::max);
+
+    // Binary search for the correct radius.
+    // For perspective: radius = camera distance (changes apparent size).
+    // For ortho: PanOrbitCamera maps radius → `OrthographicProjection::scale`,
+    //   so searching over radius effectively searches over scale.
+    let mut min_radius = object_radius * MIN_RADIUS_MULTIPLIER;
+    let mut max_radius = object_radius * MAX_RADIUS_MULTIPLIER;
+    let mut best_radius = object_radius * INITIAL_RADIUS_MULTIPLIER;
+    let mut best_focus = geometric_center;
+    let mut best_error = f32::INFINITY;
+    let mut found_projectable_bounds = false;
+
+    debug!("Binary search starting: range [{min_radius:.1}, {max_radius:.1}]");
+
+    for iteration in 0..MAX_ITERATIONS {
+        let test_radius = (min_radius + max_radius) * 0.5;
+
+        // Build the projection to use for this iteration.
+        // For ortho, we need to compute what `area` would be at this test scale.
+        let test_projection = build_test_projection(projection, test_radius);
+
+        // Step 1: find the centered focus using accurate depth-based centering
+        let centered_focus = refine_focus_centering(
+            points,
+            geometric_center,
+            test_radius,
+            rot,
+            &test_projection,
+            aspect_ratio,
+            ortho_fixed_distance,
+            is_ortho,
+        );
+
+        // Step 2: evaluate margins at the centered focus position.
+        // For ortho, the camera distance is fixed regardless of test_radius.
+        let cam_distance = ortho_fixed_distance.unwrap_or(test_radius);
+        let cam_pos = centered_focus + rot * Vec3::new(0.0, 0.0, cam_distance);
+        let cam_global =
+            GlobalTransform::from(Transform::from_translation(cam_pos).with_rotation(rot));
+
+        let Some((bounds, _)) =
+            ScreenSpaceBounds::from_points(points, &cam_global, &test_projection, aspect_ratio)
+        else {
+            warn!(
+                "Iteration {iteration}: Points behind camera at radius {test_radius:.1}, searching higher"
+            );
+            min_radius = test_radius;
+            continue;
+        };
+        found_projectable_bounds = true;
+
+        let (target_margin_x, target_margin_y) = calculate_target_margins(&bounds, zoom_multiplier);
+
+        // Find constraining dimension (minimum margin)
+        let h_min = bounds.left_margin.min(bounds.right_margin);
+        let v_min = bounds.top_margin.min(bounds.bottom_margin);
+
+        let (current_margin, target_margin, dimension) = if h_min < v_min {
+            (h_min, target_margin_x, "H")
+        } else {
+            (v_min, target_margin_y, "V")
+        };
+
+        debug!(
+            "Iteration {iteration}: radius={test_radius:.1} | {dimension} margin={current_margin:.3} \
+             target={target_margin:.3} | L={:.3} R={:.3} T={:.3} B={:.3} | range=[{min_radius:.1}, {max_radius:.1}]",
+            bounds.left_margin, bounds.right_margin, bounds.top_margin, bounds.bottom_margin
+        );
+
+        // Track the closest match to target margin
+        let margin_error = (current_margin - target_margin).abs();
+        if margin_error < best_error {
+            best_error = margin_error;
+            best_radius = test_radius;
+            best_focus = centered_focus;
+        }
+
+        if current_margin > target_margin {
+            max_radius = test_radius;
+        } else {
+            min_radius = test_radius;
+        }
+
+        if (max_radius - min_radius) < TOLERANCE {
+            debug!(
+                "Iteration {iteration}: Converged to best radius {best_radius:.3} error={best_error:.5}"
+            );
+            return Ok(FitSolution {
+                radius: best_radius,
+                focus: best_focus,
+            });
+        }
+    }
+
+    if !found_projectable_bounds {
+        return Err(FitError::PointsBehindCamera);
+    }
+
+    warn!(
+        "Binary search did not converge in {MAX_ITERATIONS} iterations. Using best radius {best_radius:.1}"
+    );
+
+    Ok(FitSolution {
+        radius: best_radius,
+        focus: best_focus,
+    })
+}
+
+/// Builds a test projection with the given radius/scale for binary search iterations.
+///
+/// For perspective, returns the original projection unchanged.
+/// For orthographic, creates a modified projection with `area` recomputed for the test scale,
+/// since `PanOrbitCamera` maps `radius` → `OrthographicProjection::scale`.
+fn build_test_projection(projection: &Projection, test_radius: f32) -> Projection {
+    match projection {
+        Projection::Perspective(_) => projection.clone(),
+        Projection::Orthographic(ortho) => {
+            // Compute what the area would be at this scale.
+            // The current area is `base_size * current_scale`, so base_size = area / scale.
+            // At test scale: new_area = base_size * test_radius.
+            let current_scale = ortho.scale;
+            let scale_ratio = if current_scale.abs() > f32::EPSILON {
+                test_radius / current_scale
+            } else {
+                1.0
+            };
+            let new_area = Rect::new(
+                ortho.area.min.x * scale_ratio,
+                ortho.area.min.y * scale_ratio,
+                ortho.area.max.x * scale_ratio,
+                ortho.area.max.y * scale_ratio,
+            );
+            Projection::Orthographic(OrthographicProjection {
+                scale: test_radius,
+                area: new_area,
+                ..*ortho
+            })
+        }
+        _ => projection.clone(),
+    }
+}
+
+/// Shifts the camera focus so the projected bounding box is centered on screen.
+///
+/// For perspective, each correction step uses the harmonic mean of the depths of the two
+/// extreme points per dimension. This is the exact inverse of perspective projection.
+///
+/// For orthographic, centering is depth-independent (centering_depth = 1.0), so the shift
+/// is a direct 1:1 world-unit correction.
+#[allow(clippy::too_many_arguments)]
+fn refine_focus_centering(
+    points: &[Vec3],
+    initial_focus: Vec3,
+    radius: f32,
+    rot: Quat,
+    projection: &Projection,
+    aspect_ratio: f32,
+    ortho_fixed_distance: Option<f32>,
+    is_ortho: bool,
+) -> Vec3 {
+    let cam_right = rot * Vec3::X;
+    let cam_up = rot * Vec3::Y;
+
+    let cam_distance = ortho_fixed_distance.unwrap_or(radius);
+
+    let mut focus = initial_focus;
+    for _ in 0..CENTERING_MAX_ITERATIONS {
+        let cam_pos = focus + rot * Vec3::new(0.0, 0.0, cam_distance);
+        let cam_global =
+            GlobalTransform::from(Transform::from_translation(cam_pos).with_rotation(rot));
+        let Some((bounds, depths)) =
+            ScreenSpaceBounds::from_points(points, &cam_global, projection, aspect_ratio)
+        else {
+            break;
+        };
+        let (cx, cy) = bounds.center();
+        if cx.abs() < CENTERING_TOLERANCE && cy.abs() < CENTERING_TOLERANCE {
+            break;
+        }
+
+        // Centering depths: perspective uses harmonic mean for perspective-correct
+        // centering. Ortho uses 1.0 since projection is depth-independent.
+        let (centering_depth_x, centering_depth_y) = if is_ortho {
+            (1.0, 1.0)
+        } else {
+            (
+                2.0 * depths.min_x_depth * depths.max_x_depth
+                    / (depths.min_x_depth + depths.max_x_depth),
+                2.0 * depths.min_y_depth * depths.max_y_depth
+                    / (depths.min_y_depth + depths.max_y_depth),
+            )
+        };
+
+        focus += cam_right * cx * centering_depth_x + cam_up * cy * centering_depth_y;
+    }
+    focus
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_perspective() -> Projection {
+        Projection::Perspective(PerspectiveProjection::default())
+    }
+
+    #[test]
+    fn calculate_fit_returns_no_viewport_for_invalid_ortho_area() {
+        let projection = Projection::Orthographic(OrthographicProjection {
+            area: Rect::new(-1.0, 0.0, 1.0, 0.0),
+            ..OrthographicProjection::default_3d()
+        });
+        let camera = Camera::default();
+
+        let result = calculate_fit(
+            &[Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0)],
+            Vec3::ZERO,
+            0.0,
+            0.0,
+            0.1,
+            &projection,
+            &camera,
+        );
+
+        assert!(matches!(result, Err(FitError::NoViewport)));
+    }
+
+    #[test]
+    fn calculate_fit_returns_points_behind_camera_for_degenerate_point_cloud() {
+        let projection = default_perspective();
+        let camera = Camera::default();
+        let points = [Vec3::ZERO, Vec3::ZERO, Vec3::ZERO];
+
+        let result = calculate_fit(&points, Vec3::ZERO, 0.0, 0.0, 0.1, &projection, &camera);
+
+        assert!(matches!(result, Err(FitError::PointsBehindCamera)));
+    }
+
+    #[test]
+    fn calculate_fit_clamps_out_of_range_margin_and_still_returns_solution() {
+        let projection = default_perspective();
+        let camera = Camera::default();
+        let points = [
+            Vec3::new(-1.0, -1.0, 0.0),
+            Vec3::new(1.0, -1.0, 0.0),
+            Vec3::new(-1.0, 1.0, 0.0),
+            Vec3::new(1.0, 1.0, 0.0),
+        ];
+
+        let result = calculate_fit(&points, Vec3::ZERO, 0.0, 0.0, 5.0, &projection, &camera);
+
+        let fit = result.expect("fit should succeed with clamped margin");
+        assert!(fit.radius.is_finite());
+        assert!(fit.focus.is_finite());
+    }
+
+    #[test]
+    fn calculate_fit_handles_nan_margin_by_clamping_to_zero() {
+        let projection = default_perspective();
+        let camera = Camera::default();
+        let points = [
+            Vec3::new(-1.0, -1.0, 0.0),
+            Vec3::new(1.0, -1.0, 0.0),
+            Vec3::new(-1.0, 1.0, 0.0),
+            Vec3::new(1.0, 1.0, 0.0),
+        ];
+
+        let result = calculate_fit(
+            &points,
+            Vec3::ZERO,
+            0.0,
+            0.0,
+            f32::NAN,
+            &projection,
+            &camera,
+        );
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -1,0 +1,31 @@
+//! Camera extras: zoom-to-fit, queued animations, and debug visualization.
+//!
+//! Enabled via the `extras` feature flag. All public types are re-exported
+//! at the crate root.
+
+pub(crate) mod animation;
+pub(crate) mod components;
+pub(crate) mod events;
+pub(crate) mod fit;
+mod observers;
+mod support;
+#[cfg(feature = "extras_debug")]
+pub(crate) mod visualization;
+
+use bevy::prelude::*;
+
+/// Registers extras observers, systems, and optional visualization.
+pub(super) fn build_extras(app: &mut App) {
+    app.add_observer(observers::on_camera_move_list_added)
+        .add_observer(observers::restore_camera_state)
+        .add_observer(observers::on_zoom_to_fit)
+        .add_observer(observers::on_play_animation)
+        .add_observer(observers::on_set_fit_target)
+        .add_observer(observers::on_animate_to_fit)
+        .add_observer(observers::on_look_at)
+        .add_observer(observers::on_look_at_and_zoom_to_fit)
+        .add_systems(Update, animation::process_camera_move_list);
+
+    #[cfg(feature = "extras_debug")]
+    app.add_plugins(visualization::VisualizationPlugin);
+}

--- a/src/extras/observers.rs
+++ b/src/extras/observers.rs
@@ -1,0 +1,654 @@
+//! Observers that wire events to camera behavior.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use bevy::math::curve::easing::EaseFunction;
+use bevy::prelude::*;
+
+use super::animation::orbital_params_from_offset;
+use super::animation::CameraMove;
+use super::animation::CameraMoveList;
+use super::components::AnimationConflictPolicy;
+use super::components::AnimationSourceMarker;
+use super::components::CameraInputInterruptBehavior;
+use super::components::CurrentFitTarget;
+use super::components::PanOrbitCameraStash;
+use super::components::ZoomAnimationMarker;
+use super::events::AnimateToFit;
+use super::events::AnimationBegin;
+use super::events::AnimationCancelled;
+use super::events::AnimationEnd;
+use super::events::AnimationRejected;
+use super::events::AnimationSource;
+use super::events::LookAt;
+use super::events::LookAtAndZoomToFit;
+use super::events::PlayAnimation;
+use super::events::SetFitTarget;
+use super::events::ZoomBegin;
+use super::events::ZoomCancelled;
+use super::events::ZoomContext;
+use super::events::ZoomEnd;
+use super::events::ZoomToFit;
+use super::fit::calculate_fit;
+use super::fit::FitSolution;
+use super::support::extract_mesh_vertices;
+use crate::PanOrbitCamera;
+
+/// Parameters for an instant orbital snap.
+struct SnapOrbit {
+    focus: Vec3,
+    yaw: Option<f32>,
+    pitch: Option<f32>,
+    radius: f32,
+}
+
+/// Snaps the camera to an orbital position instantly (no animation) and fires
+/// caller-provided lifecycle events via `emit_events`.
+fn snap_to_orbit(
+    commands: &mut Commands,
+    panorbit: &mut PanOrbitCamera,
+    snap: SnapOrbit,
+    emit_events: impl FnOnce(&mut Commands),
+) {
+    panorbit.focus = snap.focus;
+    panorbit.radius = Some(snap.radius);
+    panorbit.target_focus = snap.focus;
+    panorbit.target_radius = snap.radius;
+    if let Some(yaw) = snap.yaw {
+        panorbit.yaw = Some(yaw);
+        panorbit.target_yaw = yaw;
+    }
+    if let Some(pitch) = snap.pitch {
+        panorbit.pitch = Some(pitch);
+        panorbit.target_pitch = pitch;
+    }
+    panorbit.force_update = true;
+
+    emit_events(commands);
+}
+
+/// Ensures camera runtime state is stashed once and animation overrides are applied.
+fn stash_camera_state(
+    commands: &mut Commands,
+    entity: Entity,
+    camera: &mut PanOrbitCamera,
+    has_existing_stash: bool,
+    interrupt_behavior: CameraInputInterruptBehavior,
+) {
+    if !has_existing_stash {
+        let stash = PanOrbitCameraStash {
+            zoom: camera.zoom_smoothness,
+            pan: camera.pan_smoothness,
+            orbit: camera.orbit_smoothness,
+            enabled: camera.enabled,
+        };
+        commands.entity(entity).insert(stash);
+    }
+
+    camera.zoom_smoothness = 0.0;
+    camera.pan_smoothness = 0.0;
+    camera.orbit_smoothness = 0.0;
+
+    if interrupt_behavior == CameraInputInterruptBehavior::Ignore {
+        camera.enabled = false;
+    }
+}
+
+/// Shared fit preparation used by both ZoomToFit and AnimateToFit observers.
+/// Extracts target mesh vertices and computes the fit solution for the requested
+/// camera orientation.
+#[allow(clippy::too_many_arguments)]
+fn prepare_fit_for_target(
+    context: &str,
+    target: Entity,
+    yaw: f32,
+    pitch: f32,
+    margin: f32,
+    projection: &Projection,
+    camera: &Camera,
+    mesh_query: &Query<&Mesh3d>,
+    children_query: &Query<&Children>,
+    global_transform_query: &Query<&GlobalTransform>,
+    meshes: &Assets<Mesh>,
+) -> Option<FitSolution> {
+    let Some((vertices, geometric_center)) = extract_mesh_vertices(
+        target,
+        children_query,
+        mesh_query,
+        global_transform_query,
+        meshes,
+    ) else {
+        warn!("{context}: Failed to extract mesh vertices for entity {target:?}");
+        return None;
+    };
+
+    let fit = match calculate_fit(
+        &vertices,
+        geometric_center,
+        yaw,
+        pitch,
+        margin,
+        projection,
+        camera,
+    ) {
+        Ok(fit) => fit,
+        Err(error) => {
+            warn!("{context}: Failed to calculate fit for entity {target:?}: {error}");
+            return None;
+        }
+    };
+
+    Some(fit)
+}
+
+/// Observer for `ZoomToFit` event - frames a target entity in the camera view.
+/// When duration is `Duration::ZERO`, snaps instantly.
+/// When duration is greater than zero, animates smoothly via [`PlayAnimation`]
+/// with a [`ZoomContext`] so that `on_play_animation` handles all conflict
+/// resolution and zoom lifecycle events in one place.
+/// Requires target entity to have a `Mesh3d` (direct or on descendants).
+pub(super) fn on_zoom_to_fit(
+    zoom: On<ZoomToFit>,
+    mut commands: Commands,
+    mut camera_query: Query<(&mut PanOrbitCamera, &Projection, &Camera)>,
+    mesh_query: Query<&Mesh3d>,
+    children_query: Query<&Children>,
+    global_transform_query: Query<&GlobalTransform>,
+    meshes: Res<Assets<Mesh>>,
+) {
+    let camera = zoom.camera;
+    let target = zoom.target;
+    let margin = zoom.margin;
+    let duration = zoom.duration;
+    let easing = zoom.easing;
+
+    let Ok((mut panorbit, projection, cam)) = camera_query.get_mut(camera) else {
+        return;
+    };
+
+    debug!(
+        "ZoomToFit: yaw={:.3} pitch={:.3} current_focus={:.1?} current_radius={:.1} duration_ms={:.0}",
+        panorbit.target_yaw,
+        panorbit.target_pitch,
+        panorbit.target_focus,
+        panorbit.target_radius,
+        duration.as_secs_f32() * 1000.0,
+    );
+
+    let Some(fit) = prepare_fit_for_target(
+        "ZoomToFit",
+        target,
+        panorbit.target_yaw,
+        panorbit.target_pitch,
+        margin,
+        projection,
+        cam,
+        &mesh_query,
+        &children_query,
+        &global_transform_query,
+        &meshes,
+    ) else {
+        return;
+    };
+
+    if duration > Duration::ZERO {
+        // Animated path: use `ToOrbit` to pass orbital params directly, avoiding
+        // gimbal lock from atan2 decomposition at extreme pitch angles.
+        let camera_moves = VecDeque::from([CameraMove::ToOrbit {
+            focus: fit.focus,
+            yaw: panorbit.target_yaw,
+            pitch: panorbit.target_pitch,
+            radius: fit.radius,
+            duration,
+            easing,
+        }]);
+
+        let ctx = ZoomContext {
+            target,
+            margin,
+            duration,
+            easing,
+        };
+
+        // `on_play_animation` handles conflict resolution, `ZoomBegin`, and
+        // `ZoomAnimationMarker` insertion — all in one place after acceptance.
+        commands.trigger(PlayAnimation::new(camera, camera_moves).zoom_context(ctx));
+    } else {
+        // Instant path: snap directly to target — no `PlayAnimation` involved.
+        snap_to_orbit(
+            &mut commands,
+            &mut panorbit,
+            SnapOrbit {
+                focus: fit.focus,
+                yaw: None,
+                pitch: None,
+                radius: fit.radius,
+            },
+            |commands| {
+                commands.trigger(ZoomBegin {
+                    camera,
+                    target,
+                    margin,
+                    duration,
+                    easing,
+                });
+                commands.trigger(ZoomEnd {
+                    camera,
+                    target,
+                    margin,
+                    duration: Duration::ZERO,
+                    easing,
+                });
+            },
+        );
+    }
+
+    // Route fit target updates through a single lifecycle owner.
+    commands.trigger(SetFitTarget::new(camera, target));
+}
+
+/// Fires `ZoomBegin` and inserts `ZoomAnimationMarker` when the accepted
+/// animation carries zoom context.
+fn begin_zoom_if_needed(
+    commands: &mut Commands,
+    entity: Entity,
+    zoom_context: &Option<ZoomContext>,
+) {
+    if let Some(ctx) = zoom_context {
+        commands.trigger(ZoomBegin {
+            camera: entity,
+            target: ctx.target,
+            margin: ctx.margin,
+            duration: ctx.duration,
+            easing: ctx.easing,
+        });
+        commands
+            .entity(entity)
+            .insert(ZoomAnimationMarker(ctx.clone()));
+    }
+}
+
+/// Observer for `PlayAnimation` event - initiates camera animation sequence.
+/// This is the single decision point for all trigger-time logic: conflict
+/// resolution, zoom lifecycle (`ZoomBegin` / `ZoomAnimationMarker`), and
+/// animation begin.
+#[allow(clippy::type_complexity)]
+pub(super) fn on_play_animation(
+    start: On<PlayAnimation>,
+    mut commands: Commands,
+    mut camera_query: Query<(
+        &mut PanOrbitCamera,
+        Option<&PanOrbitCameraStash>,
+        Option<&CameraInputInterruptBehavior>,
+        Option<&AnimationConflictPolicy>,
+    )>,
+    move_list_query: Query<&CameraMoveList>,
+    marker_query: Query<&ZoomAnimationMarker>,
+    source_marker_query: Query<&AnimationSourceMarker>,
+) {
+    let entity = start.camera;
+    let zoom_context = start.zoom_context.clone();
+    let source = if zoom_context.is_some() {
+        AnimationSource::ZoomToFit
+    } else {
+        start.source
+    };
+
+    let Ok((mut camera, existing_stash, interrupt_behavior, conflict_policy)) =
+        camera_query.get_mut(entity)
+    else {
+        return;
+    };
+
+    let interrupt_behavior = interrupt_behavior.copied().unwrap_or_default();
+    let policy = conflict_policy.copied().unwrap_or_default();
+    let has_in_flight = move_list_query.get(entity).is_ok();
+
+    if has_in_flight {
+        match policy {
+            AnimationConflictPolicy::FirstWins => {
+                commands.trigger(AnimationRejected {
+                    camera: entity,
+                    source,
+                });
+                return;
+            }
+            AnimationConflictPolicy::LastWins => {
+                // Cancel in-flight animation — read source from existing marker
+                let in_flight_source = source_marker_query
+                    .get(entity)
+                    .map_or(AnimationSource::PlayAnimation, |m| m.0);
+                if let Ok(queue) = move_list_query.get(entity) {
+                    let camera_move =
+                        queue
+                            .camera_moves
+                            .front()
+                            .cloned()
+                            .unwrap_or(CameraMove::ToOrbit {
+                                focus: Vec3::ZERO,
+                                yaw: 0.0,
+                                pitch: 0.0,
+                                radius: 1.0,
+                                duration: Duration::ZERO,
+                                easing: EaseFunction::Linear,
+                            });
+                    commands.trigger(AnimationCancelled {
+                        camera: entity,
+                        source: in_flight_source,
+                        camera_move,
+                    });
+                }
+                // Cancel in-flight zoom if present
+                if let Ok(marker) = marker_query.get(entity) {
+                    commands.entity(entity).remove::<ZoomAnimationMarker>();
+                    commands.trigger(ZoomCancelled {
+                        camera: entity,
+                        target: marker.0.target,
+                        margin: marker.0.margin,
+                        duration: marker.0.duration,
+                        easing: marker.0.easing,
+                    });
+                }
+            }
+        }
+    }
+
+    // Zoom lifecycle fires here — after conflict resolution has passed.
+    // No command-ordering hazard since everything happens in the same observer.
+    begin_zoom_if_needed(&mut commands, entity, &zoom_context);
+
+    commands.trigger(AnimationBegin {
+        camera: entity,
+        source,
+    });
+
+    stash_camera_state(
+        &mut commands,
+        entity,
+        &mut camera,
+        existing_stash.is_some(),
+        interrupt_behavior,
+    );
+
+    commands
+        .entity(entity)
+        .insert(CameraMoveList::new(start.camera_moves.clone()));
+    commands
+        .entity(entity)
+        .insert(AnimationSourceMarker(source));
+}
+
+/// Observer for direct `CameraMoveList` insertion (bypassing `PlayAnimation`).
+/// Reuses the same camera-state stashing behavior as the event-driven path.
+pub(super) fn on_camera_move_list_added(
+    add: On<Add, CameraMoveList>,
+    mut commands: Commands,
+    mut camera_query: Query<(
+        &mut PanOrbitCamera,
+        Option<&PanOrbitCameraStash>,
+        Option<&CameraInputInterruptBehavior>,
+    )>,
+) {
+    let entity = add.entity;
+    let Ok((mut camera, existing_stash, interrupt_behavior)) = camera_query.get_mut(entity) else {
+        return;
+    };
+    let interrupt_behavior = interrupt_behavior.copied().unwrap_or_default();
+
+    stash_camera_state(
+        &mut commands,
+        entity,
+        &mut camera,
+        existing_stash.is_some(),
+        interrupt_behavior,
+    );
+}
+
+/// Observer for `SetFitTarget` event - sets the target entity for fit visualization.
+pub(super) fn on_set_fit_target(set_target: On<SetFitTarget>, mut commands: Commands) {
+    commands
+        .entity(set_target.camera)
+        .insert(CurrentFitTarget(set_target.target));
+}
+
+/// Observer for `AnimateToFit` event - animates the camera to a specific orientation
+/// while fitting a target entity in view.
+pub(super) fn on_animate_to_fit(
+    event: On<AnimateToFit>,
+    mut commands: Commands,
+    mut camera_query: Query<(&mut PanOrbitCamera, &Projection, &Camera)>,
+    mesh_query: Query<&Mesh3d>,
+    children_query: Query<&Children>,
+    global_transform_query: Query<&GlobalTransform>,
+    meshes: Res<Assets<Mesh>>,
+) {
+    let camera = event.camera;
+    let target = event.target;
+    let yaw = event.yaw;
+    let pitch = event.pitch;
+    let margin = event.margin;
+    let duration = event.duration;
+    let easing = event.easing;
+
+    let Ok((mut panorbit, projection, cam)) = camera_query.get_mut(camera) else {
+        return;
+    };
+
+    let Some(fit) = prepare_fit_for_target(
+        "AnimateToFit",
+        target,
+        yaw,
+        pitch,
+        margin,
+        projection,
+        cam,
+        &mesh_query,
+        &children_query,
+        &global_transform_query,
+        &meshes,
+    ) else {
+        return;
+    };
+
+    if duration > Duration::ZERO {
+        let camera_moves = VecDeque::from([CameraMove::ToOrbit {
+            focus: fit.focus,
+            yaw,
+            pitch,
+            radius: fit.radius,
+            duration,
+            easing,
+        }]);
+        commands.trigger(
+            PlayAnimation::new(camera, camera_moves).source(AnimationSource::AnimateToFit),
+        );
+    } else {
+        snap_to_orbit(
+            &mut commands,
+            &mut panorbit,
+            SnapOrbit {
+                focus: fit.focus,
+                yaw: Some(yaw),
+                pitch: Some(pitch),
+                radius: fit.radius,
+            },
+            |commands| {
+                let source = AnimationSource::AnimateToFit;
+                commands.trigger(AnimationBegin { camera, source });
+                commands.trigger(AnimationEnd { camera, source });
+            },
+        );
+    }
+    // Route fit target updates through a single lifecycle owner.
+    commands.trigger(SetFitTarget::new(camera, target));
+}
+
+/// Observer for `LookAt` event — rotates the camera in place to look at a target entity.
+/// The camera stays at its current world position; only the orbit pivot re-anchors.
+pub(super) fn on_look_at(
+    event: On<LookAt>,
+    mut commands: Commands,
+    mut camera_query: Query<(&mut PanOrbitCamera, &GlobalTransform)>,
+    global_transform_query: Query<&GlobalTransform>,
+) {
+    let camera = event.camera;
+    let target = event.target;
+    let duration = event.duration;
+    let easing = event.easing;
+
+    let Ok((mut panorbit, cam_transform)) = camera_query.get_mut(camera) else {
+        return;
+    };
+
+    let Ok(target_transform) = global_transform_query.get(target) else {
+        warn!("LookAt: target {target:?} has no GlobalTransform");
+        return;
+    };
+
+    let cam_pos = cam_transform.translation();
+    let target_pos = target_transform.translation();
+
+    if duration > Duration::ZERO {
+        commands.trigger(
+            PlayAnimation::new(
+                camera,
+                [CameraMove::ToPosition {
+                    translation: cam_pos,
+                    focus: target_pos,
+                    duration,
+                    easing,
+                }],
+            )
+            .source(AnimationSource::LookAt),
+        );
+    } else {
+        // Instant path: back-solve orbital params and snap
+        let (yaw, pitch, radius) = orbital_params_from_offset(cam_pos - target_pos);
+        snap_to_orbit(
+            &mut commands,
+            &mut panorbit,
+            SnapOrbit {
+                focus: target_pos,
+                yaw: Some(yaw),
+                pitch: Some(pitch),
+                radius,
+            },
+            |commands| {
+                let source = AnimationSource::LookAt;
+                commands.trigger(AnimationBegin { camera, source });
+                commands.trigger(AnimationEnd { camera, source });
+            },
+        );
+    }
+}
+
+/// Observer for `LookAtAndZoomToFit` event — rotates the camera in place to look at
+/// a target entity and adjusts the radius to frame it, all in one fluid motion.
+/// The yaw and pitch are back-solved from the camera's current world position.
+pub(super) fn on_look_at_and_zoom_to_fit(
+    event: On<LookAtAndZoomToFit>,
+    mut commands: Commands,
+    mut camera_query: Query<(&mut PanOrbitCamera, &Projection, &Camera, &GlobalTransform)>,
+    mesh_query: Query<&Mesh3d>,
+    children_query: Query<&Children>,
+    global_transform_query: Query<&GlobalTransform>,
+    meshes: Res<Assets<Mesh>>,
+) {
+    let camera = event.camera;
+    let target = event.target;
+    let margin = event.margin;
+    let duration = event.duration;
+    let easing = event.easing;
+
+    let Ok((mut panorbit, projection, cam, cam_transform)) = camera_query.get_mut(camera) else {
+        return;
+    };
+
+    let cam_pos = cam_transform.translation();
+
+    // Back-solve yaw/pitch from camera's current position relative to the target.
+    // We need the target's bounds center for this, so we run the fit calculation
+    // with a preliminary yaw/pitch, then refine.
+    let Ok(target_gt) = global_transform_query.get(target) else {
+        warn!("LookAtAndZoomToFit: target {target:?} has no GlobalTransform");
+        return;
+    };
+    let target_pos = target_gt.translation();
+    let (preliminary_yaw, preliminary_pitch, _) = orbital_params_from_offset(cam_pos - target_pos);
+
+    let Some(fit) = prepare_fit_for_target(
+        "LookAtAndZoomToFit",
+        target,
+        preliminary_yaw,
+        preliminary_pitch,
+        margin,
+        projection,
+        cam,
+        &mesh_query,
+        &children_query,
+        &global_transform_query,
+        &meshes,
+    ) else {
+        return;
+    };
+
+    // Recompute yaw/pitch relative to the fit's focus (bounds center), which may
+    // differ slightly from the raw `GlobalTransform` translation.
+    let (yaw, pitch, _) = orbital_params_from_offset(cam_pos - fit.focus);
+
+    if duration > Duration::ZERO {
+        commands.trigger(
+            PlayAnimation::new(
+                camera,
+                [CameraMove::ToOrbit {
+                    focus: fit.focus,
+                    yaw,
+                    pitch,
+                    radius: fit.radius,
+                    duration,
+                    easing,
+                }],
+            )
+            .source(AnimationSource::LookAtAndZoomToFit),
+        );
+    } else {
+        snap_to_orbit(
+            &mut commands,
+            &mut panorbit,
+            SnapOrbit {
+                focus: fit.focus,
+                yaw: Some(yaw),
+                pitch: Some(pitch),
+                radius: fit.radius,
+            },
+            |commands| {
+                let source = AnimationSource::LookAtAndZoomToFit;
+                commands.trigger(AnimationBegin { camera, source });
+                commands.trigger(AnimationEnd { camera, source });
+            },
+        );
+    }
+
+    commands.trigger(SetFitTarget::new(camera, target));
+}
+
+/// Observer that restores camera runtime state when `CameraMoveList` is removed.
+pub(super) fn restore_camera_state(
+    remove: On<Remove, CameraMoveList>,
+    mut commands: Commands,
+    mut query: Query<(&PanOrbitCameraStash, &mut PanOrbitCamera)>,
+) {
+    let entity = remove.entity;
+
+    let Ok((stash, mut camera)) = query.get_mut(entity) else {
+        return;
+    };
+
+    camera.zoom_smoothness = stash.zoom;
+    camera.pan_smoothness = stash.pan;
+    camera.orbit_smoothness = stash.orbit;
+    camera.enabled = stash.enabled;
+
+    commands.entity(entity).remove::<PanOrbitCameraStash>();
+}

--- a/src/extras/observers.rs
+++ b/src/extras/observers.rs
@@ -95,7 +95,7 @@ fn stash_camera_state(
     }
 }
 
-/// Shared fit preparation used by both ZoomToFit and AnimateToFit observers.
+/// Shared fit preparation used by both `ZoomToFit` and `AnimateToFit` observers.
 /// Extracts target mesh vertices and computes the fit solution for the requested
 /// camera orientation.
 #[allow(clippy::too_many_arguments)]

--- a/src/extras/support.rs
+++ b/src/extras/support.rs
@@ -38,9 +38,9 @@ pub(super) const MIN_VISIBLE_DEPTH: f32 = 0.1;
 /// Projection-derived parameters for screen-space normalization.
 /// Consolidates the extraction of half extents and projection type from a `Projection`.
 pub(super) struct ProjectionParams {
-    /// Half visible extent in x (perspective: half_tan_hfov, ortho: area.width()/2)
+    /// Half visible extent in x (perspective: `half_tan_hfov`, ortho: `area.width()/2`)
     pub half_extent_x: f32,
-    /// Half visible extent in y (perspective: half_tan_vfov, ortho: area.height()/2)
+    /// Half visible extent in y (perspective: `half_tan_vfov`, ortho: `area.height()/2`)
     pub half_extent_y: f32,
     /// Whether this uses orthographic projection
     pub is_ortho: bool,
@@ -152,9 +152,9 @@ pub(super) struct ScreenSpaceBounds {
     pub min_norm_y: f32,
     /// Maximum normalized y coordinate in screen space
     pub max_norm_y: f32,
-    /// Half visible extent in x (perspective: half_tan_hfov, ortho: area.width()/2)
+    /// Half visible extent in x (perspective: `half_tan_hfov`, ortho: `area.width()/2`)
     pub half_extent_x: f32,
-    /// Half visible extent in y (perspective: half_tan_vfov, ortho: area.height()/2)
+    /// Half visible extent in y (perspective: `half_tan_vfov`, ortho: `area.height()/2`)
     pub half_extent_y: f32,
 }
 

--- a/src/extras/support.rs
+++ b/src/extras/support.rs
@@ -1,0 +1,313 @@
+//! Shared utility functions used across multiple modules.
+
+use bevy::prelude::*;
+
+// ============================================================================
+// Camera basis
+// ============================================================================
+
+/// Camera basis vectors extracted from a `GlobalTransform`.
+/// Bundles the position and orientation vectors that are frequently passed together.
+pub(super) struct CameraBasis {
+    pub pos: Vec3,
+    pub right: Vec3,
+    pub up: Vec3,
+    pub forward: Vec3,
+}
+
+impl CameraBasis {
+    pub fn from_global_transform(global: &GlobalTransform) -> Self {
+        let rot = global.rotation();
+        Self {
+            pos: global.translation(),
+            right: rot * Vec3::X,
+            up: rot * Vec3::Y,
+            forward: rot * Vec3::NEG_Z,
+        }
+    }
+}
+
+// ============================================================================
+// Projection utilities
+// ============================================================================
+
+/// Minimum depth for a point to be considered in front of the camera.
+/// Points at or below this depth are treated as behind the camera in perspective projection.
+pub(super) const MIN_VISIBLE_DEPTH: f32 = 0.1;
+
+/// Projection-derived parameters for screen-space normalization.
+/// Consolidates the extraction of half extents and projection type from a `Projection`.
+pub(super) struct ProjectionParams {
+    /// Half visible extent in x (perspective: half_tan_hfov, ortho: area.width()/2)
+    pub half_extent_x: f32,
+    /// Half visible extent in y (perspective: half_tan_vfov, ortho: area.height()/2)
+    pub half_extent_y: f32,
+    /// Whether this uses orthographic projection
+    pub is_ortho: bool,
+}
+
+impl ProjectionParams {
+    /// Extracts projection parameters from a `Projection` and viewport aspect ratio.
+    /// Returns `None` for unsupported projection variants.
+    pub fn from_projection(projection: &Projection, viewport_aspect: f32) -> Option<Self> {
+        let is_ortho = matches!(projection, Projection::Orthographic(_));
+        let (half_extent_x, half_extent_y) = match projection {
+            Projection::Perspective(p) => {
+                let half_tan_vfov = (p.fov * 0.5).tan();
+                (half_tan_vfov * viewport_aspect, half_tan_vfov)
+            }
+            Projection::Orthographic(o) => (o.area.width() * 0.5, o.area.height() * 0.5),
+            _ => return None,
+        };
+        Some(Self {
+            half_extent_x,
+            half_extent_y,
+            is_ortho,
+        })
+    }
+}
+
+/// Projects a world-space point to normalized screen coordinates.
+///
+/// Returns `(norm_x, norm_y, depth)` or `None` if the point is behind the camera
+/// (perspective only — orthographic points are always valid).
+pub(super) fn project_point(
+    point: Vec3,
+    cam: &CameraBasis,
+    is_ortho: bool,
+) -> Option<(f32, f32, f32)> {
+    let relative = point - cam.pos;
+    let depth = relative.dot(cam.forward);
+    if !is_ortho && depth <= MIN_VISIBLE_DEPTH {
+        return None;
+    }
+    let x = relative.dot(cam.right);
+    let y = relative.dot(cam.up);
+    let (norm_x, norm_y) = if is_ortho {
+        (x, y)
+    } else {
+        (x / depth, y / depth)
+    };
+    Some((norm_x, norm_y, depth))
+}
+
+/// Extracts the aspect ratio from a `Projection`, using `viewport_size` for
+/// perspective when available, falling back to `PerspectiveProjection::aspect_ratio`.
+///
+/// Returns `None` for orthographic projections with zero-height area or unknown
+/// projection variants.
+pub(super) fn projection_aspect_ratio(
+    projection: &Projection,
+    viewport_size: Option<Vec2>,
+) -> Option<f32> {
+    match projection {
+        Projection::Perspective(p) => Some(viewport_size.map_or(p.aspect_ratio, |s| s.x / s.y)),
+        Projection::Orthographic(o) => {
+            let area = o.area;
+            if area.height().abs() < f32::EPSILON {
+                return None;
+            }
+            Some(area.width() / area.height())
+        }
+        _ => None,
+    }
+}
+
+// ============================================================================
+// Screen-space bounds
+// ============================================================================
+
+/// Depths of the extreme projected points, tracked during the projection loop.
+/// Used by the fit algorithm for perspective-correct centering (harmonic mean)
+/// and by visualization for average depth (gizmo placement).
+#[derive(Debug, Clone)]
+pub(super) struct PointDepths {
+    pub min_x_depth: f32,
+    pub max_x_depth: f32,
+    pub min_y_depth: f32,
+    pub max_y_depth: f32,
+    #[cfg(feature = "extras_debug")]
+    pub depth_sum: f32,
+    #[cfg(feature = "extras_debug")]
+    pub point_count: usize,
+}
+
+/// Screen-space bounds of a set of projected points, with margin distances
+/// from each screen edge.
+#[derive(Debug, Clone)]
+pub(super) struct ScreenSpaceBounds {
+    /// Distance from left edge (positive = inside, negative = outside)
+    pub left_margin: f32,
+    /// Distance from right edge (positive = inside, negative = outside)
+    pub right_margin: f32,
+    /// Distance from top edge (positive = inside, negative = outside)
+    pub top_margin: f32,
+    /// Distance from bottom edge (positive = inside, negative = outside)
+    pub bottom_margin: f32,
+    /// Minimum normalized x coordinate in screen space
+    pub min_norm_x: f32,
+    /// Maximum normalized x coordinate in screen space
+    pub max_norm_x: f32,
+    /// Minimum normalized y coordinate in screen space
+    pub min_norm_y: f32,
+    /// Maximum normalized y coordinate in screen space
+    pub max_norm_y: f32,
+    /// Half visible extent in x (perspective: half_tan_hfov, ortho: area.width()/2)
+    pub half_extent_x: f32,
+    /// Half visible extent in y (perspective: half_tan_vfov, ortho: area.height()/2)
+    pub half_extent_y: f32,
+}
+
+impl ScreenSpaceBounds {
+    /// Projects world-space points to normalized screen space and computes margins.
+    /// Returns `None` if any point is behind the camera (perspective only).
+    pub fn from_points(
+        points: &[Vec3],
+        cam_global: &GlobalTransform,
+        projection: &Projection,
+        viewport_aspect: f32,
+    ) -> Option<(Self, PointDepths)> {
+        let ProjectionParams {
+            half_extent_x,
+            half_extent_y,
+            is_ortho,
+        } = ProjectionParams::from_projection(projection, viewport_aspect)?;
+
+        let cam = CameraBasis::from_global_transform(cam_global);
+
+        let mut min_norm_x = f32::INFINITY;
+        let mut max_norm_x = f32::NEG_INFINITY;
+        let mut min_norm_y = f32::INFINITY;
+        let mut max_norm_y = f32::NEG_INFINITY;
+        let mut min_x_depth = 0.0_f32;
+        let mut max_x_depth = 0.0_f32;
+        let mut min_y_depth = 0.0_f32;
+        let mut max_y_depth = 0.0_f32;
+        #[cfg(feature = "extras_debug")]
+        let mut depth_sum = 0.0_f32;
+
+        for point in points {
+            let (norm_x, norm_y, depth) = project_point(*point, &cam, is_ortho)?;
+
+            #[cfg(feature = "extras_debug")]
+            {
+                depth_sum += depth;
+            }
+
+            if norm_x < min_norm_x {
+                min_norm_x = norm_x;
+                min_x_depth = depth;
+            }
+            if norm_x > max_norm_x {
+                max_norm_x = norm_x;
+                max_x_depth = depth;
+            }
+            if norm_y < min_norm_y {
+                min_norm_y = norm_y;
+                min_y_depth = depth;
+            }
+            if norm_y > max_norm_y {
+                max_norm_y = norm_y;
+                max_y_depth = depth;
+            }
+        }
+
+        let left_margin = min_norm_x - (-half_extent_x);
+        let right_margin = half_extent_x - max_norm_x;
+        let bottom_margin = min_norm_y - (-half_extent_y);
+        let top_margin = half_extent_y - max_norm_y;
+
+        let bounds = Self {
+            left_margin,
+            right_margin,
+            top_margin,
+            bottom_margin,
+            min_norm_x,
+            max_norm_x,
+            min_norm_y,
+            max_norm_y,
+            half_extent_x,
+            half_extent_y,
+        };
+
+        let depths = PointDepths {
+            min_x_depth,
+            max_x_depth,
+            min_y_depth,
+            max_y_depth,
+            #[cfg(feature = "extras_debug")]
+            depth_sum,
+            #[cfg(feature = "extras_debug")]
+            point_count: points.len(),
+        };
+
+        Some((bounds, depths))
+    }
+
+    /// Returns the center of the bounds in normalized screen space.
+    pub const fn center(&self) -> (f32, f32) {
+        let center_x = (self.min_norm_x + self.max_norm_x) * 0.5;
+        let center_y = (self.min_norm_y + self.max_norm_y) * 0.5;
+        (center_x, center_y)
+    }
+}
+
+// ============================================================================
+// Mesh utilities
+// ============================================================================
+
+/// Extracts world-space vertex positions from all meshes on an entity and its descendants.
+/// Returns `(vertices, geometric_center)` where `geometric_center` is the root entity's
+/// `GlobalTransform` translation.
+pub(super) fn extract_mesh_vertices(
+    entity: Entity,
+    children_query: &Query<&Children>,
+    mesh_query: &Query<&Mesh3d>,
+    global_transform_query: &Query<&GlobalTransform>,
+    meshes: &Assets<Mesh>,
+) -> Option<(Vec<Vec3>, Vec3)> {
+    let mesh_entities: Vec<Entity> = std::iter::once(entity)
+        .chain(children_query.iter_descendants(entity))
+        .filter(|e| mesh_query.get(*e).is_ok())
+        .collect();
+
+    if mesh_entities.is_empty() {
+        return None;
+    }
+
+    let mut all_vertices = Vec::new();
+
+    for mesh_entity in &mesh_entities {
+        let Ok(mesh3d) = mesh_query.get(*mesh_entity) else {
+            continue;
+        };
+        let Some(mesh) = meshes.get(&mesh3d.0) else {
+            continue;
+        };
+        let Ok(global_transform) = global_transform_query.get(*mesh_entity) else {
+            continue;
+        };
+        let Some(positions) = mesh
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(|a| a.as_float3())
+        else {
+            continue;
+        };
+
+        all_vertices.extend(
+            positions
+                .iter()
+                .map(|pos| global_transform.transform_point(Vec3::from_array(*pos))),
+        );
+    }
+
+    if all_vertices.is_empty() {
+        return None;
+    }
+
+    let geometric_center = global_transform_query
+        .get(entity)
+        .map_or(Vec3::ZERO, |gt| gt.translation());
+
+    Some((all_vertices, geometric_center))
+}

--- a/src/extras/visualization/convex_hull.rs
+++ b/src/extras/visualization/convex_hull.rs
@@ -1,0 +1,66 @@
+use bevy::prelude::*;
+
+use super::super::support::project_point;
+use super::super::support::CameraBasis;
+
+/// 2D cross product for three points (for convex hull turn detection).
+fn cross_2d(o: (f32, f32), a: (f32, f32), b: (f32, f32)) -> f32 {
+    (a.0 - o.0) * (b.1 - o.1) - (a.1 - o.1) * (b.0 - o.0)
+}
+
+/// Andrew's monotone chain algorithm for 2D convex hull.
+/// Returns hull vertices in counter-clockwise order.
+pub fn convex_hull_2d(points: &[(f32, f32)]) -> Vec<(f32, f32)> {
+    let mut sorted: Vec<(f32, f32)> = points.to_vec();
+    sorted.sort_by(|a, b| {
+        a.0.partial_cmp(&b.0)
+            .unwrap()
+            .then(a.1.partial_cmp(&b.1).unwrap())
+    });
+    sorted.dedup();
+
+    if sorted.len() <= 1 {
+        return sorted;
+    }
+
+    let mut lower: Vec<(f32, f32)> = Vec::new();
+    for &p in &sorted {
+        while lower.len() >= 2 && cross_2d(lower[lower.len() - 2], lower[lower.len() - 1], p) <= 0.0
+        {
+            lower.pop();
+        }
+        lower.push(p);
+    }
+
+    let mut upper: Vec<(f32, f32)> = Vec::new();
+    for &p in sorted.iter().rev() {
+        while upper.len() >= 2 && cross_2d(upper[upper.len() - 2], upper[upper.len() - 1], p) <= 0.0
+        {
+            upper.pop();
+        }
+        upper.push(p);
+    }
+
+    lower.pop();
+    upper.pop();
+
+    lower.extend(upper);
+    lower
+}
+
+/// Projects world-space vertices to 2D normalized screen space.
+///
+/// For perspective, divides by depth. For orthographic, uses raw camera-space coordinates.
+pub fn project_vertices_to_2d(
+    vertices: &[Vec3],
+    cam: &CameraBasis,
+    is_ortho: bool,
+) -> Vec<(f32, f32)> {
+    vertices
+        .iter()
+        .filter_map(|v| {
+            let (norm_x, norm_y, _) = project_point(*v, cam, is_ortho)?;
+            Some((norm_x, norm_y))
+        })
+        .collect()
+}

--- a/src/extras/visualization/labels.rs
+++ b/src/extras/visualization/labels.rs
@@ -1,0 +1,187 @@
+use bevy::prelude::*;
+use bevy::ui::UiTargetCamera;
+
+use super::super::fit::Edge;
+use super::super::support::ScreenSpaceBounds;
+use super::screen_space::norm_to_viewport;
+use super::screen_space::screen_edge_center;
+
+/// Font size used for all debug labels.
+const LABEL_FONT_SIZE: f32 = 11.0;
+/// Pixel offset used to keep labels off line endpoints and screen edges.
+const LABEL_PIXEL_OFFSET: f32 = 8.0;
+
+/// Component marking margin percentage labels, scoped to a specific camera entity.
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+pub struct MarginLabel {
+    pub edge: Edge,
+    pub camera: Entity,
+}
+
+/// Parameters for creating or updating a margin label.
+pub struct MarginLabelParams {
+    pub camera: Entity,
+    pub edge: Edge,
+    pub text: String,
+    pub color: Color,
+    pub screen_pos: Vec2,
+    pub viewport_size: Vec2,
+}
+
+/// Component marking the "screen space bounds" label, scoped to a specific camera entity.
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+pub struct BoundsLabel {
+    pub camera: Entity,
+}
+
+/// Calculates the viewport pixel position for a margin label, offset by a fixed
+/// number of pixels from the screen-edge endpoint of the margin line.
+pub fn calculate_label_pixel_position(
+    edge: Edge,
+    bounds: &ScreenSpaceBounds,
+    viewport_size: Vec2,
+) -> Vec2 {
+    let (screen_x, screen_y) = screen_edge_center(bounds, edge);
+    let px = norm_to_viewport(
+        screen_x,
+        screen_y,
+        bounds.half_extent_x,
+        bounds.half_extent_y,
+        viewport_size,
+    );
+
+    // Left/Right labels sit above the horizontal line;
+    // Top/Bottom labels sit beside the vertical line with pixel offsets.
+    let above_line = px.y - LABEL_FONT_SIZE - LABEL_PIXEL_OFFSET;
+
+    match edge {
+        Edge::Left => Vec2::new(LABEL_PIXEL_OFFSET, above_line),
+        Edge::Right => Vec2::new(viewport_size.x - LABEL_PIXEL_OFFSET, above_line),
+        Edge::Top => Vec2::new(px.x + LABEL_PIXEL_OFFSET, LABEL_PIXEL_OFFSET),
+        Edge::Bottom => Vec2::new(
+            px.x + LABEL_PIXEL_OFFSET,
+            viewport_size.y - LABEL_PIXEL_OFFSET,
+        ),
+    }
+}
+
+/// Returns the final viewport position for the "screen space bounds" label.
+pub fn bounds_label_position(upper_left: Vec2) -> Vec2 {
+    Vec2::new(
+        upper_left.x + LABEL_PIXEL_OFFSET,
+        upper_left.y - LABEL_FONT_SIZE - LABEL_PIXEL_OFFSET,
+    )
+}
+
+/// Applies anchored placement for a margin label node based on edge semantics.
+fn apply_margin_label_anchor(node: &mut Node, edge: Edge, screen_pos: Vec2, viewport_size: Vec2) {
+    match edge {
+        Edge::Left | Edge::Top => {
+            node.left = Val::Px(screen_pos.x);
+            node.top = Val::Px(screen_pos.y);
+            node.right = Val::Auto;
+            node.bottom = Val::Auto;
+        }
+        Edge::Right => {
+            node.right = Val::Px(viewport_size.x - screen_pos.x);
+            node.top = Val::Px(screen_pos.y);
+            node.left = Val::Auto;
+            node.bottom = Val::Auto;
+        }
+        Edge::Bottom => {
+            node.left = Val::Px(screen_pos.x);
+            node.bottom = Val::Px(viewport_size.y - screen_pos.y);
+            node.right = Val::Auto;
+            node.top = Val::Auto;
+        }
+    }
+}
+
+/// Builds an anchored node for a new margin label.
+fn margin_label_node(edge: Edge, screen_pos: Vec2, viewport_size: Vec2) -> Node {
+    let mut node = Node {
+        position_type: PositionType::Absolute,
+        ..default()
+    };
+    apply_margin_label_anchor(&mut node, edge, screen_pos, viewport_size);
+    node
+}
+
+/// Updates an existing margin label or creates a new one.
+pub fn update_or_create_margin_label(
+    commands: &mut Commands,
+    label_query: &mut Query<(Entity, &MarginLabel, &mut Text, &mut Node, &mut TextColor)>,
+    params: MarginLabelParams,
+) {
+    let mut found = false;
+    for (_, label, mut label_text, mut node, mut text_color) in label_query {
+        if label.camera == params.camera && label.edge == params.edge {
+            **label_text = params.text.clone();
+            text_color.0 = params.color;
+            apply_margin_label_anchor(
+                &mut node,
+                params.edge,
+                params.screen_pos,
+                params.viewport_size,
+            );
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        commands.spawn((
+            Text::new(params.text),
+            TextFont {
+                font_size: LABEL_FONT_SIZE,
+                ..default()
+            },
+            TextColor(params.color),
+            margin_label_node(params.edge, params.screen_pos, params.viewport_size),
+            MarginLabel {
+                edge: params.edge,
+                camera: params.camera,
+            },
+            UiTargetCamera(params.camera),
+        ));
+    }
+}
+
+/// Updates an existing bounds label position or creates a new one.
+pub fn update_or_create_bounds_label(
+    commands: &mut Commands,
+    bounds_query: &mut Query<(Entity, &BoundsLabel, &mut Node), Without<MarginLabel>>,
+    camera: Entity,
+    screen_pos: Vec2,
+) {
+    let mut found = false;
+    for (_, label, mut node) in bounds_query.iter_mut() {
+        if label.camera == camera {
+            node.left = Val::Px(screen_pos.x);
+            node.top = Val::Px(screen_pos.y);
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        commands.spawn((
+            Text::new("screen space bounds"),
+            TextFont {
+                font_size: LABEL_FONT_SIZE,
+                ..default()
+            },
+            TextColor(Color::srgb(1.0, 1.0, 0.0)),
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(screen_pos.x),
+                top: Val::Px(screen_pos.y),
+                ..default()
+            },
+            BoundsLabel { camera },
+            UiTargetCamera(camera),
+        ));
+    }
+}

--- a/src/extras/visualization/mod.rs
+++ b/src/extras/visualization/mod.rs
@@ -1,0 +1,85 @@
+//! Visualization system for fit target debugging.
+//!
+//! Provides screen-aligned boundary box and silhouette polygon visualization for the current
+//! camera fit target. Uses Bevy's GizmoConfigGroup pattern (similar to Avian3D's PhysicsGizmos).
+
+mod convex_hull;
+mod labels;
+mod screen_space;
+mod systems;
+mod types;
+
+use bevy::camera::visibility::RenderLayers;
+use bevy::prelude::*;
+use labels::BoundsLabel;
+use labels::MarginLabel;
+pub use types::FitTargetGizmo;
+use types::FitTargetViewportMargins;
+pub use types::FitTargetVisualizationConfig;
+
+use super::components::FitVisualization;
+
+/// Plugin that enables fit target debug visualization.
+pub(super) struct VisualizationPlugin;
+
+impl Plugin for VisualizationPlugin {
+    fn build(&self, app: &mut App) {
+        if app.is_plugin_added::<bevy::gizmos::GizmoPlugin>() {
+            app.init_gizmo_group::<FitTargetGizmo>();
+        }
+
+        app.init_resource::<FitTargetVisualizationConfig>()
+            .add_observer(on_remove_fit_visualization)
+            .add_systems(
+                Update,
+                (sync_gizmo_render_layers, systems::draw_fit_target_bounds)
+                    .chain()
+                    .run_if(any_with_component::<FitVisualization>),
+            );
+    }
+}
+
+/// Observer that cleans up visualization state when `FitVisualization` is removed from a camera.
+fn on_remove_fit_visualization(
+    trigger: On<Remove, FitVisualization>,
+    mut commands: Commands,
+    label_query: Query<(Entity, &MarginLabel)>,
+    bounds_label_query: Query<(Entity, &BoundsLabel)>,
+) {
+    let camera = trigger.entity;
+
+    // Clean up viewport margins from the camera entity.
+    // `try_remove` silently skips if the entity was despawned this frame
+    // (e.g. closing a secondary window triggers component removal during despawn).
+    commands
+        .entity(camera)
+        .try_remove::<FitTargetViewportMargins>();
+
+    // Clean up labels belonging to this camera
+    for (entity, label) in &label_query {
+        if label.camera == camera {
+            commands.entity(entity).despawn();
+        }
+    }
+    for (entity, label) in &bounds_label_query {
+        if label.camera == camera {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Syncs the gizmo render layers and line width with visualization-enabled cameras.
+fn sync_gizmo_render_layers(
+    mut config_store: ResMut<GizmoConfigStore>,
+    viz_config: Res<FitTargetVisualizationConfig>,
+    camera_query: Query<Option<&RenderLayers>, With<FitVisualization>>,
+) {
+    let (gizmo_config, _) = config_store.config_mut::<FitTargetGizmo>();
+    gizmo_config.line.width = viz_config.line_width;
+    gizmo_config.depth_bias = -1.0;
+
+    // Apply render layers from the first visualization-enabled camera
+    if let Some(Some(layers)) = camera_query.iter().next() {
+        gizmo_config.render_layers = layers.clone();
+    }
+}

--- a/src/extras/visualization/mod.rs
+++ b/src/extras/visualization/mod.rs
@@ -1,7 +1,7 @@
 //! Visualization system for fit target debugging.
 //!
 //! Provides screen-aligned boundary box and silhouette polygon visualization for the current
-//! camera fit target. Uses Bevy's GizmoConfigGroup pattern (similar to Avian3D's PhysicsGizmos).
+//! camera fit target. Uses Bevy's `GizmoConfigGroup` pattern (similar to `Avian3D`'s `PhysicsGizmos`).
 
 mod convex_hull;
 mod labels;

--- a/src/extras/visualization/screen_space.rs
+++ b/src/extras/visualization/screen_space.rs
@@ -1,0 +1,120 @@
+use bevy::prelude::*;
+
+use super::super::fit::Edge;
+use super::super::support::CameraBasis;
+use super::super::support::ScreenSpaceBounds;
+
+/// Returns true if horizontal margins are balanced.
+pub fn is_horizontally_balanced(bounds: &ScreenSpaceBounds, tolerance: f32) -> bool {
+    (bounds.left_margin - bounds.right_margin).abs() < tolerance
+}
+
+/// Returns true if vertical margins are balanced.
+pub fn is_vertically_balanced(bounds: &ScreenSpaceBounds, tolerance: f32) -> bool {
+    (bounds.top_margin - bounds.bottom_margin).abs() < tolerance
+}
+
+/// Returns the screen edges in normalized space: (left, right, top, bottom).
+fn screen_edges_normalized(bounds: &ScreenSpaceBounds) -> (f32, f32, f32, f32) {
+    (
+        -bounds.half_extent_x,
+        bounds.half_extent_x,
+        bounds.half_extent_y,
+        -bounds.half_extent_y,
+    )
+}
+
+/// Returns the clamped vertical center of the bounds within the screen edges.
+fn clamped_center_y(bounds: &ScreenSpaceBounds, bottom_edge: f32, top_edge: f32) -> f32 {
+    (bounds.min_norm_y.max(bottom_edge) + bounds.max_norm_y.min(top_edge)) * 0.5
+}
+
+/// Returns the clamped horizontal center of the bounds within the screen edges.
+fn clamped_center_x(bounds: &ScreenSpaceBounds, left_edge: f32, right_edge: f32) -> f32 {
+    (bounds.min_norm_x.max(left_edge) + bounds.max_norm_x.min(right_edge)) * 0.5
+}
+
+/// Returns the center of a boundary edge in normalized space.
+pub fn boundary_edge_center(bounds: &ScreenSpaceBounds, edge: Edge) -> Option<(f32, f32)> {
+    let (left_edge, right_edge, top_edge, bottom_edge) = screen_edges_normalized(bounds);
+
+    match edge {
+        Edge::Left if bounds.min_norm_x > left_edge => Some((
+            bounds.min_norm_x,
+            clamped_center_y(bounds, bottom_edge, top_edge),
+        )),
+        Edge::Right if bounds.max_norm_x < right_edge => Some((
+            bounds.max_norm_x,
+            clamped_center_y(bounds, bottom_edge, top_edge),
+        )),
+        Edge::Top if bounds.max_norm_y < top_edge => Some((
+            clamped_center_x(bounds, left_edge, right_edge),
+            bounds.max_norm_y,
+        )),
+        Edge::Bottom if bounds.min_norm_y > bottom_edge => Some((
+            clamped_center_x(bounds, left_edge, right_edge),
+            bounds.min_norm_y,
+        )),
+        _ => None,
+    }
+}
+
+/// Returns the center of a screen edge in normalized space.
+pub fn screen_edge_center(bounds: &ScreenSpaceBounds, edge: Edge) -> (f32, f32) {
+    let (left_edge, right_edge, top_edge, bottom_edge) = screen_edges_normalized(bounds);
+
+    match edge {
+        Edge::Left => (left_edge, clamped_center_y(bounds, bottom_edge, top_edge)),
+        Edge::Right => (right_edge, clamped_center_y(bounds, bottom_edge, top_edge)),
+        Edge::Top => (clamped_center_x(bounds, left_edge, right_edge), top_edge),
+        Edge::Bottom => (clamped_center_x(bounds, left_edge, right_edge), bottom_edge),
+    }
+}
+
+/// Converts normalized screen-space coordinates to world space.
+///
+/// For perspective, reverses the perspective divide by multiplying by `avg_depth`.
+/// For orthographic, coordinates are already in world units — `avg_depth` is only
+/// used for the forward component to position the gizmo plane.
+pub fn normalized_to_world(
+    norm_x: f32,
+    norm_y: f32,
+    cam: &CameraBasis,
+    avg_depth: f32,
+    is_ortho: bool,
+) -> Vec3 {
+    let (world_x, world_y) = if is_ortho {
+        (norm_x, norm_y)
+    } else {
+        (norm_x * avg_depth, norm_y * avg_depth)
+    };
+    cam.pos + cam.right * world_x + cam.up * world_y + cam.forward * avg_depth
+}
+
+/// Returns the margin percentage for a given edge.
+/// Percentage represents how much of the screen width/height is margin.
+pub fn margin_percentage(bounds: &ScreenSpaceBounds, edge: Edge) -> f32 {
+    let screen_width = 2.0 * bounds.half_extent_x;
+    let screen_height = 2.0 * bounds.half_extent_y;
+
+    match edge {
+        Edge::Left => (bounds.left_margin / screen_width) * 100.0,
+        Edge::Right => (bounds.right_margin / screen_width) * 100.0,
+        Edge::Top => (bounds.top_margin / screen_height) * 100.0,
+        Edge::Bottom => (bounds.bottom_margin / screen_height) * 100.0,
+    }
+}
+
+/// Converts a normalized screen-space coordinate to viewport pixels.
+pub fn norm_to_viewport(
+    norm_x: f32,
+    norm_y: f32,
+    half_extent_x: f32,
+    half_extent_y: f32,
+    viewport_size: Vec2,
+) -> Vec2 {
+    Vec2::new(
+        (norm_x / half_extent_x + 1.0) * 0.5 * viewport_size.x,
+        (1.0 - norm_y / half_extent_y) * 0.5 * viewport_size.y,
+    )
+}

--- a/src/extras/visualization/systems.rs
+++ b/src/extras/visualization/systems.rs
@@ -1,0 +1,309 @@
+use bevy::prelude::*;
+
+use super::super::components::CurrentFitTarget;
+use super::super::components::FitVisualization;
+use super::super::fit;
+use super::super::fit::Edge;
+use super::super::support::extract_mesh_vertices;
+use super::super::support::projection_aspect_ratio;
+use super::super::support::CameraBasis;
+use super::super::support::ScreenSpaceBounds;
+use super::convex_hull::convex_hull_2d;
+use super::convex_hull::project_vertices_to_2d;
+use super::labels::bounds_label_position;
+use super::labels::calculate_label_pixel_position;
+use super::labels::update_or_create_bounds_label;
+use super::labels::update_or_create_margin_label;
+use super::labels::BoundsLabel;
+use super::labels::MarginLabel;
+use super::labels::MarginLabelParams;
+use super::screen_space::boundary_edge_center;
+use super::screen_space::is_horizontally_balanced;
+use super::screen_space::is_vertically_balanced;
+use super::screen_space::margin_percentage;
+use super::screen_space::norm_to_viewport;
+use super::screen_space::normalized_to_world;
+use super::screen_space::screen_edge_center;
+use super::types::FitTargetGizmo;
+use super::types::FitTargetViewportMargins;
+use super::types::FitTargetVisualizationConfig;
+
+/// Calculates the color for an edge based on balance state.
+const fn calculate_edge_color(
+    edge: Edge,
+    h_balanced: bool,
+    v_balanced: bool,
+    config: &FitTargetVisualizationConfig,
+) -> Color {
+    match edge {
+        Edge::Left | Edge::Right => {
+            if h_balanced {
+                config.balanced_color
+            } else {
+                config.unbalanced_color
+            }
+        }
+        Edge::Top | Edge::Bottom => {
+            if v_balanced {
+                config.balanced_color
+            } else {
+                config.unbalanced_color
+            }
+        }
+    }
+}
+
+/// Creates the 4 corners of the screen-aligned boundary rectangle in world space.
+fn create_screen_corners(
+    bounds: &ScreenSpaceBounds,
+    cam: &CameraBasis,
+    avg_depth: f32,
+    is_ortho: bool,
+) -> [Vec3; 4] {
+    [
+        normalized_to_world(
+            bounds.min_norm_x,
+            bounds.min_norm_y,
+            cam,
+            avg_depth,
+            is_ortho,
+        ),
+        normalized_to_world(
+            bounds.max_norm_x,
+            bounds.min_norm_y,
+            cam,
+            avg_depth,
+            is_ortho,
+        ),
+        normalized_to_world(
+            bounds.max_norm_x,
+            bounds.max_norm_y,
+            cam,
+            avg_depth,
+            is_ortho,
+        ),
+        normalized_to_world(
+            bounds.min_norm_x,
+            bounds.max_norm_y,
+            cam,
+            avg_depth,
+            is_ortho,
+        ),
+    ]
+}
+
+/// Draws the boundary rectangle outline.
+fn draw_rectangle(
+    gizmos: &mut Gizmos<FitTargetGizmo>,
+    corners: &[Vec3; 4],
+    config: &FitTargetVisualizationConfig,
+) {
+    for i in 0..4 {
+        let next = (i + 1) % 4;
+        gizmos.line(corners[i], corners[next], config.rectangle_color);
+    }
+}
+
+/// Draws the silhouette polygon (convex hull of projected vertices) using gizmo lines.
+fn draw_silhouette(
+    gizmos: &mut Gizmos<FitTargetGizmo>,
+    vertices: &[Vec3],
+    cam: &CameraBasis,
+    avg_depth: f32,
+    is_ortho: bool,
+    color: Color,
+) {
+    let projected = project_vertices_to_2d(vertices, cam, is_ortho);
+    let hull = convex_hull_2d(&projected);
+
+    if hull.len() < 2 {
+        return;
+    }
+
+    for i in 0..hull.len() {
+        let next = (i + 1) % hull.len();
+        let start = normalized_to_world(hull[i].0, hull[i].1, cam, avg_depth, is_ortho);
+        let end = normalized_to_world(hull[next].0, hull[next].1, cam, avg_depth, is_ortho);
+        gizmos.line(start, end, color);
+    }
+}
+
+/// Draws margin lines from boundary edges to screen edges and updates margin labels.
+/// Returns the set of edges that had visible margins.
+#[allow(clippy::too_many_arguments)]
+fn draw_margin_lines_and_labels(
+    commands: &mut Commands,
+    gizmos: &mut Gizmos<FitTargetGizmo>,
+    label_query: &mut Query<(Entity, &MarginLabel, &mut Text, &mut Node, &mut TextColor)>,
+    camera: Entity,
+    bounds: &ScreenSpaceBounds,
+    cam_basis: &CameraBasis,
+    avg_depth: f32,
+    is_ortho: bool,
+    config: &FitTargetVisualizationConfig,
+    viewport_size: Option<Vec2>,
+) -> Vec<Edge> {
+    let h_balanced = is_horizontally_balanced(bounds, fit::TOLERANCE);
+    let v_balanced = is_vertically_balanced(bounds, fit::TOLERANCE);
+
+    let mut visible_edges: Vec<Edge> = Vec::new();
+
+    for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+        let Some((boundary_x, boundary_y)) = boundary_edge_center(bounds, edge) else {
+            continue;
+        };
+        visible_edges.push(edge);
+
+        let (screen_x, screen_y) = screen_edge_center(bounds, edge);
+        let boundary_pos =
+            normalized_to_world(boundary_x, boundary_y, cam_basis, avg_depth, is_ortho);
+        let screen_pos = normalized_to_world(screen_x, screen_y, cam_basis, avg_depth, is_ortho);
+
+        let color = calculate_edge_color(edge, h_balanced, v_balanced, config);
+        gizmos.line(boundary_pos, screen_pos, color);
+
+        let Some(vp) = viewport_size else {
+            continue;
+        };
+        let percentage = margin_percentage(bounds, edge);
+        let text = format!("margin: {percentage:.3}%");
+        let label_screen_pos = calculate_label_pixel_position(edge, bounds, vp);
+
+        update_or_create_margin_label(
+            commands,
+            label_query,
+            MarginLabelParams {
+                camera,
+                edge,
+                text,
+                color,
+                screen_pos: label_screen_pos,
+                viewport_size: vp,
+            },
+        );
+    }
+
+    visible_edges
+}
+
+/// Removes margin labels for edges no longer visible, scoped to a specific camera.
+fn cleanup_stale_margin_labels(
+    commands: &mut Commands,
+    label_query: &Query<(Entity, &MarginLabel, &mut Text, &mut Node, &mut TextColor)>,
+    camera: Entity,
+    visible_edges: &[Edge],
+) {
+    for (entity, label, _, _, _) in label_query {
+        if label.camera == camera && !visible_edges.contains(&label.edge) {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Draws screen-aligned bounds for all cameras with `FitVisualization`.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn draw_fit_target_bounds(
+    mut commands: Commands,
+    mut gizmos: Gizmos<FitTargetGizmo>,
+    config: Res<FitTargetVisualizationConfig>,
+    camera_query: Query<
+        (
+            Entity,
+            &Camera,
+            &GlobalTransform,
+            &Projection,
+            &CurrentFitTarget,
+        ),
+        With<FitVisualization>,
+    >,
+    mesh_query: Query<&Mesh3d>,
+    children_query: Query<&Children>,
+    global_transform_query: Query<&GlobalTransform>,
+    meshes: Res<Assets<Mesh>>,
+    mut label_query: Query<(Entity, &MarginLabel, &mut Text, &mut Node, &mut TextColor)>,
+    mut bounds_label_query: Query<(Entity, &BoundsLabel, &mut Node), Without<MarginLabel>>,
+) {
+    for (camera, cam, cam_global, projection, current_target) in &camera_query {
+        let Some((vertices, _)) = extract_mesh_vertices(
+            current_target.0,
+            &children_query,
+            &mesh_query,
+            &global_transform_query,
+            &meshes,
+        ) else {
+            continue;
+        };
+
+        let cam_basis = CameraBasis::from_global_transform(cam_global);
+
+        let Some(aspect_ratio) = projection_aspect_ratio(projection, cam.logical_viewport_size())
+        else {
+            continue;
+        };
+
+        let Some((bounds, depths)) =
+            ScreenSpaceBounds::from_points(&vertices, cam_global, projection, aspect_ratio)
+        else {
+            continue;
+        };
+
+        let avg_depth = depths.depth_sum / depths.point_count as f32;
+        let is_ortho = matches!(projection, Projection::Orthographic(_));
+        let viewport_size = cam.logical_viewport_size();
+
+        // Update margin percentages on camera entity for BRP inspection.
+        // `try_insert` silently skips if the entity was despawned this frame
+        // (e.g. closing a secondary window while visualization is active).
+        commands
+            .entity(camera)
+            .try_insert(FitTargetViewportMargins::from_bounds(&bounds));
+
+        // Bounding rectangle
+        let corners = create_screen_corners(&bounds, &cam_basis, avg_depth, is_ortho);
+        draw_rectangle(&mut gizmos, &corners, &config);
+
+        // Silhouette convex hull
+        draw_silhouette(
+            &mut gizmos,
+            &vertices,
+            &cam_basis,
+            avg_depth,
+            is_ortho,
+            config.silhouette_color,
+        );
+
+        // "Screen space bounds" label
+        if let Some(vp) = viewport_size {
+            let upper_left = norm_to_viewport(
+                bounds.min_norm_x,
+                bounds.max_norm_y,
+                bounds.half_extent_x,
+                bounds.half_extent_y,
+                vp,
+            );
+            update_or_create_bounds_label(
+                &mut commands,
+                &mut bounds_label_query,
+                camera,
+                bounds_label_position(upper_left),
+            );
+        }
+
+        // Margin lines + labels
+        let visible_edges = draw_margin_lines_and_labels(
+            &mut commands,
+            &mut gizmos,
+            &mut label_query,
+            camera,
+            &bounds,
+            &cam_basis,
+            avg_depth,
+            is_ortho,
+            &config,
+            viewport_size,
+        );
+
+        // Remove stale margin labels for this camera
+        cleanup_stale_margin_labels(&mut commands, &label_query, camera, &visible_edges);
+    }
+}

--- a/src/extras/visualization/types.rs
+++ b/src/extras/visualization/types.rs
@@ -1,0 +1,67 @@
+use bevy::prelude::*;
+
+use super::super::support::ScreenSpaceBounds;
+
+/// Gizmo config group for fit target visualization (screen-aligned overlay).
+/// Toggle by inserting/removing the `FitVisualization` component on the camera entity.
+#[derive(Default, Reflect, GizmoConfigGroup)]
+pub struct FitTargetGizmo;
+
+/// Current screen-space margin percentages for the fit target.
+/// Updated every frame by the visualization system.
+/// Removed when fit target visualization is disabled.
+#[derive(Component, Reflect, Debug, Default, Clone)]
+#[reflect(Component)]
+pub struct FitTargetViewportMargins {
+    /// Left margin as a percentage of screen width.
+    pub left_pct: f32,
+    /// Right margin as a percentage of screen width.
+    pub right_pct: f32,
+    /// Top margin as a percentage of screen height.
+    pub top_pct: f32,
+    /// Bottom margin as a percentage of screen height.
+    pub bottom_pct: f32,
+}
+
+impl FitTargetViewportMargins {
+    /// Constructs margin percentages from screen-space bounds, computing
+    /// screen dimensions once rather than per-edge.
+    pub fn from_bounds(bounds: &ScreenSpaceBounds) -> Self {
+        let screen_width = 2.0 * bounds.half_extent_x;
+        let screen_height = 2.0 * bounds.half_extent_y;
+        Self {
+            left_pct: (bounds.left_margin / screen_width) * 100.0,
+            right_pct: (bounds.right_margin / screen_width) * 100.0,
+            top_pct: (bounds.top_margin / screen_height) * 100.0,
+            bottom_pct: (bounds.bottom_margin / screen_height) * 100.0,
+        }
+    }
+}
+
+/// Configuration for fit target visualization colors and appearance.
+#[derive(Resource, Reflect, Debug, Clone)]
+#[reflect(Resource)]
+pub struct FitTargetVisualizationConfig {
+    /// Color for the screen-aligned bounding rectangle.
+    pub rectangle_color: Color,
+    /// Color for the silhouette convex hull.
+    pub silhouette_color: Color,
+    /// Color for balanced margins (left ≈ right, top ≈ bottom).
+    pub balanced_color: Color,
+    /// Color for unbalanced margins.
+    pub unbalanced_color: Color,
+    /// Line width for gizmo rendering.
+    pub line_width: f32,
+}
+
+impl Default for FitTargetVisualizationConfig {
+    fn default() -> Self {
+        Self {
+            rectangle_color: Color::srgb(1.0, 1.0, 0.0),  // Yellow
+            silhouette_color: Color::srgb(1.0, 0.5, 0.0), // Orange
+            balanced_color: Color::srgb(0.0, 1.0, 0.0),   // Green
+            unbalanced_color: Color::srgb(1.0, 0.0, 0.0), // Red
+            line_width: 2.0,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use extras::events::LookAt;
 pub use extras::events::LookAtAndZoomToFit;
 #[cfg(feature = "extras")]
 pub use extras::events::PlayAnimation;
-#[cfg(feature = "extras")]
+#[cfg(feature = "extras_debug")]
 pub use extras::events::SetFitTarget;
 #[cfg(feature = "extras")]
 pub use extras::events::ZoomBegin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,62 @@ use crate::traits::OptionalClamp;
 
 #[cfg(feature = "bevy_egui")]
 mod egui;
+#[cfg(feature = "extras")]
+mod extras;
 mod input;
 mod touch;
 mod traits;
 mod util;
+
+// Extras re-exports
+#[cfg(feature = "extras")]
+pub use extras::animation::CameraMove;
+#[cfg(feature = "extras")]
+pub use extras::animation::CameraMoveList;
+#[cfg(feature = "extras")]
+pub use extras::components::AnimationConflictPolicy;
+#[cfg(feature = "extras")]
+pub use extras::components::CameraInputInterruptBehavior;
+#[cfg(feature = "extras")]
+pub use extras::components::CurrentFitTarget;
+#[cfg(feature = "extras_debug")]
+pub use extras::components::FitVisualization;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimateToFit;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimationBegin;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimationCancelled;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimationEnd;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimationRejected;
+#[cfg(feature = "extras")]
+pub use extras::events::AnimationSource;
+#[cfg(feature = "extras")]
+pub use extras::events::CameraMoveBegin;
+#[cfg(feature = "extras")]
+pub use extras::events::CameraMoveEnd;
+#[cfg(feature = "extras")]
+pub use extras::events::LookAt;
+#[cfg(feature = "extras")]
+pub use extras::events::LookAtAndZoomToFit;
+#[cfg(feature = "extras")]
+pub use extras::events::PlayAnimation;
+#[cfg(feature = "extras")]
+pub use extras::events::SetFitTarget;
+#[cfg(feature = "extras")]
+pub use extras::events::ZoomBegin;
+#[cfg(feature = "extras")]
+pub use extras::events::ZoomCancelled;
+#[cfg(feature = "extras")]
+pub use extras::events::ZoomContext;
+#[cfg(feature = "extras")]
+pub use extras::events::ZoomEnd;
+#[cfg(feature = "extras")]
+pub use extras::events::ZoomToFit;
+#[cfg(feature = "extras_debug")]
+pub use extras::visualization::FitTargetVisualizationConfig;
 
 /// Bevy plugin that contains the systems for controlling `PanOrbitCamera` components.
 /// # Example
@@ -72,6 +124,11 @@ impl Plugin for PanOrbitCameraPlugin {
                         .after(EguiPreUpdateSet::InitContexts)
                         .before(PanOrbitCameraSystemSet),
                 );
+        }
+
+        #[cfg(feature = "extras")]
+        {
+            extras::build_extras(app);
         }
     }
 }


### PR DESCRIPTION
## Summary

After fixing a few things and polishing some more, here is the PR to add the extras. This PR integrates [`bevy_panorbit_camera_ext`](https://github.com/natepiano/bevy_panorbit_camera_ext) into the main crate behind two optional feature flags (`extras` and `extras_debug`).

Fixes #143

## What's included

**`extras` feature:**
- Zoom-to-fit (`ZoomToFit`, `AnimateToFit`, `LookAtAndZoomToFit`)
- Look-at (`LookAt`)
- Queued camera animations (`PlayAnimation`, `CameraMove`, `CameraMoveList`)
- Animation lifecycle events (`AnimationBegin`, `AnimationEnd`, `AnimationCancelled`, `AnimationRejected`, `ZoomBegin`, `ZoomEnd`, `ZoomCancelled`, `CameraMoveBegin`, `CameraMoveEnd`)
- Configurable interrupt and conflict policies (`CameraInputInterruptBehavior`, `AnimationConflictPolicy`)

**`extras_debug` feature (enabling this implicitly enables `extras`):**
- Gizmo-based debug visualization of fit target bounds
- Screen-space margin labels and silhouette convex hull rendering
- Toggle via `FitVisualization` component, configure via `FitTargetVisualizationConfig` resource
- `SetFitTarget` event for pointing the debug overlay at an entity without triggering a zoom

**Examples:**
- `extras` — full showcase with mesh picking, multi-window, animations, and debug visualization
- `extras_zoom_to_fit` — ZoomToFit with debug visualization toggle
- `extras_animate_to_fit` — AnimateToFit with target yaw/pitch
- `extras_play_animation` — 5-step queued animation sequence
- `extras_look_at` — contrasts LookAt, LookAtAndZoomToFit, and ZoomToFit

## Design decisions

- **No separate plugin** — `PanOrbitCameraPlugin::build()` conditionally registers extras observers/systems when the feature is enabled
- **Flat API** — all public types re-exported at the crate root behind `#[cfg(feature = "extras")]`
- **Internal types stay internal** — `PanOrbitCameraStash`, `ZoomAnimationMarker`, etc. use `pub(super)` visibility
- Both features are off by default — zero impact on existing users

## Test plan

- [ ] `cargo build` (default features) — extras not compiled
- [ ] `cargo build --features extras` — core extras without debug viz
- [ ] `cargo build --features extras_debug` — full build with debug viz
- [ ] `cargo build --features bevy_egui,extras_debug` — both features coexist
- [ ] `cargo clippy --features extras_debug` — clean
- [ ] `cargo nextest run --features extras_debug` — 22 tests pass (4 extras fit algorithm edge-case tests + 18 existing)
- [ ] Run each example and verify functionality

All examples have been manually tested — trackpad orbit/pan/zoom, keyboard triggers, camera reset, and debug visualization toggle all verified working.